### PR TITLE
Add Copy as Markdown button

### DIFF
--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -8,7 +8,8 @@
         "@docusaurus/core": "^3.8.1",
         "@docusaurus/faster": "^3.8.1",
         "@docusaurus/preset-classic": "^3.8.1",
-        "react-icons": "^5.5.0"
+        "react-icons": "^5.5.0",
+        "turndown": "^7.2.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -4002,6 +4003,12 @@
         "@types/react": ">=16",
         "react": ">=16"
       }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@module-federation/error-codes": {
       "version": "0.14.3",
@@ -16166,6 +16173,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "2.19.0",

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -3,7 +3,8 @@
     "@docusaurus/core": "^3.8.1",
     "@docusaurus/faster": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "turndown": "^7.2.0"
   },
   "scripts": {
     "start": "docusaurus start",

--- a/docusaurus/src/theme/TOC/styles.module.css
+++ b/docusaurus/src/theme/TOC/styles.module.css
@@ -12,7 +12,7 @@
   top: calc(var(--ifm-navbar-height) + 1rem);
 }
 
-.openChatGPTLink {
+.tocAction {
   display: flex;
   width: 100%;
   justify-content: flex-end;
@@ -25,6 +25,10 @@
   cursor: pointer;
 }
 
+.openChatGPTLink {}
+
+.copyMarkdownLink {}
+
 .openChatGPTLink::after {
   content: '↗';
   margin-left: 0.25rem;
@@ -34,6 +38,16 @@
 
 .openChatGPTLink:hover {
   text-decoration: underline;
+}
+
+.copyMarkdownLink:hover {
+  text-decoration: underline;
+}
+
+.copyIcon {
+  width: 1em;
+  height: 1em;
+  margin-right: 0.25em;
 }
 
 .chatgptIcon {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
         "@docusaurus/core": "^3.8.1",
         "@docusaurus/faster": "^3.8.1",
         "@docusaurus/preset-classic": "^3.8.1",
-        "react-icons": "^5.5.0"
+        "react-icons": "^5.5.0",
+        "turndown": "^7.2.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -4002,6 +4003,12 @@
         "@types/react": ">=16",
         "react": ">=16"
       }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@module-federation/error-codes": {
       "version": "0.14.3",
@@ -16166,6 +16173,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "2.19.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "@docusaurus/core": "^3.8.1",
     "@docusaurus/faster": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "turndown": "^7.2.0"
   },
   "scripts": {
     "start": "docusaurus start",


### PR DESCRIPTION
## Summary
- add `turndown` dependency
- add copy markdown button and styling in TOC
- remove unused `useDoc` import and refactor common button styles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688110b554308323b3e2b5b1af1d0abd