### PR TITLE
Fix ToC action button layout

### DIFF
--- a/docusaurus/src/theme/TOC/styles.module.css
+++ b/docusaurus/src/theme/TOC/styles.module.css
@@ -68,8 +68,8 @@
 
 .tocActions {
   display: flex;
-  justify-content: flex-end;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 0.5rem;
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- stack the `Open in ChatGPT` and `Copy as Markdown` buttons vertically in the table of contents

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6881513f13148323af74dc60da15be09