### PR TITLE
DTT-8: Add released-feature FAQs and cross-links across Business App docs

### DIFF
--- a/docusaurus/docs/administration/email_configuration.md
+++ b/docusaurus/docs/administration/email_configuration.md
@@ -12,6 +12,10 @@ Setting up SPF, DKIM, and DMARC is like showing an ID for your emails. It proves
 
 Configure your email settings via Business App > Settings > Email Configuration.
 
+:::info
+Business App uses HTTPS link branding for tracking links in campaign emails, which helps reduce deliverability warnings from some providers. Authenticating your domain further improves inbox placement and reputation.
+::::
+
 ## Warm up your email domain
 
 Once you've established your custom email domain, it's important to allocate a period for warming it up. Without properly warming up your domain, your emails risk being filtered out by various email service providers.
@@ -46,4 +50,16 @@ Spam traps are email addresses created by email service providers to catch spamm
 
 When your contacts open and click on your emails, it shows you're delivering content they find valuable. On the flip side, spam complaints, high bounce rates, and unsubscribes can harm your reputation as a sender. By monitoring your email performance, you can discover which content appeals to your audience and decide which contacts to focus on in future campaigns.
 
+## Frequently Asked Questions (FAQs)
 
+<details>
+<summary>What’s the difference between the shared sending domain and a custom domain?</summary>
+
+The shared sending domain is the default domain used by Business App for outbound campaigns. Many senders share it. A custom domain is your own authenticated domain (via SPF/DKIM/DMARC) that you connect to build reputation for your brand. For best deliverability and control, set up a custom domain. See [Authenticate your custom email domain](#authenticate-your-custom-email-domain).
+</details>
+
+<details>
+<summary>Which should I use—shared domain or custom domain?</summary>
+
+Use the shared domain to get started quickly. For ongoing sending, we strongly recommend a custom domain to build your own sender reputation and reduce the impact of other senders. Link tracking uses HTTPS by default and works with both.
+</details>

--- a/docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md
@@ -322,6 +322,12 @@ For additional troubleshooting, see [Conversations Phone Call Setup](../../conve
 </details>
 
 <details>
+<summary>Can the AI book meetings on my calendar?</summary>
+
+Yes. Connect your calendar in <CRMIcon /> `CRM` > `My Meetings` > `Settings` > `Defaults` > `Connect Calendar`. Then enable the **Book appointments with calendar** capability in your AI configuration. If your booking link uses Microsoft Teams or Google Meet, meeting links are included automatically. See [My Meetings](/crm/my-meetings) for details.
+</details>
+
+<details>
 <summary>Can I change my AI's knowledge or instructions after setup?</summary>
 
 Yes! You can update your AI Voice Receptionist anytime by:

--- a/docusaurus/docs/automations/index.md
+++ b/docusaurus/docs/automations/index.md
@@ -11,6 +11,9 @@ Automations let you create workflows that run on their own when specific events 
 - Apply tags, update CRM fields, or create tasks based on activity
 - Notify your team or log sales activities when messages are sent/received
 - Kick off follow‑ups after meetings, orders, or invoices
+- Trigger workflows when a conversation summary is created
+- Create tasks, notes, and logged calls on opportunities
+- Get a response from an AI Employee as part of a workflow
 
 ## How it works
 
@@ -69,3 +72,11 @@ Use the Activity tab on an automation to see what ran, when it ran, and whether 
   - See: [Templates and recipes](./templates-and-recipes.md)
 - Connect external systems with Zapier
   - See: [Zapier](./zapier.md)
+
+## Frequently Asked Questions (FAQs)
+
+<details>
+<summary>Can I get a response from an AI Employee inside an automation?</summary>
+
+Yes. Add the "Get a response from an AI Employee" action to send context (for example, a conversation summary or form submission) to your AI Employee and use the response later in the workflow.
+</details>

--- a/docusaurus/docs/crm/activity-feed.md
+++ b/docusaurus/docs/crm/activity-feed.md
@@ -19,6 +19,7 @@ Use the Activity Feed to see real-time updates on sales activities across your t
 - **Filters and search** by activity type and keywords
 - **Live updates** of recent emails, notes, calls, meetings, and tasks
 - **Links** to the underlying contact or company record for context
+- **Richer activity details** like meeting status and call outcomes at-a-glance
 
 ## How to use the Activity Feed
 
@@ -33,6 +34,12 @@ Use the Activity Feed to see real-time updates on sales activities across your t
 <summary>Can I filter by specific activity types?</summary>
 
 Yes. Use filters to focus on emails, notes, calls, meetings, and more.
+</details>
+
+<details>
+<summary>Can I delete a recorded meeting activity?</summary>
+
+Yes. Open the related record and delete the activity there; the Activity Feed will reflect the change. You can access activities from [Contacts](/crm/contacts), [Companies](/crm/companies), or [Opportunities](/crm/opportunities).
 </details>
 
 <details>

--- a/docusaurus/docs/crm/contacts.md
+++ b/docusaurus/docs/crm/contacts.md
@@ -104,6 +104,18 @@ Yes. Choose to update matches by ID, external ID, or email when reviewing the im
 </details>
 
 <details>
+<summary>Where can I see import history and errors?</summary>
+
+After an import completes, review the import summary in `CRM` > `Contacts` to see successes, failures, and error details for each row.
+</details>
+
+<details>
+<summary>How do I assign an owner during import?</summary>
+
+In the CSV, include an Owner Email column and map it during import. Matching is done against existing users; when a match is found, that user is set as the contact owner.
+</details>
+
+<details>
 <summary>Can I automatically log emails?</summary>
 
 Yes. Set up email auto-BCC and forwarding so sales emails are captured to the appropriate contact records.

--- a/docusaurus/docs/crm/forms.md
+++ b/docusaurus/docs/crm/forms.md
@@ -72,4 +72,10 @@ If using WordPress (e.g., Divi), add a “Code” block and paste the embed code
 For the form to capture UTM, they must be still present in the browser address bar. If a user clicks away from your landing page, to visit a second page on your website, and you don’t have a UTM preservation tool active, the UTM can be lost and won’t be captured if they fill out a form. One tactic to prevent this is removing all links from your landing page, to ensure leads fill out the form on the landing page and nowhere else.
 </details>
 
+<details>
+<summary>Can I trigger automations from a specific form?</summary>
+
+Yes. In Automations, choose a form submission as the trigger, then add actions like tagging, notifications, or follow‑ups. This helps route and respond to new leads consistently.
+</details>
+
 

--- a/docusaurus/docs/crm/my-meetings.md
+++ b/docusaurus/docs/crm/my-meetings.md
@@ -19,6 +19,9 @@ Use My Meetings to share booking links, manage availability, and track upcoming 
 - **Personal and team booking links**
 - **Availability settings** and buffers
 - **Calendar connections**
+- **Microsoft Outlook/365 calendar integration**
+- **Microsoft Teams video conferencing integration**
+- **Multi‑host events (up to five hosts)**
 
 ## How to use My Meetings
 
@@ -37,6 +40,24 @@ Use My Meetings to share booking links, manage availability, and track upcoming 
 <summary>Can I set different durations for meeting types?</summary>
 
 Yes. Configure durations when creating booking links.
+</details>
+
+<details>
+<summary>How many hosts can I add to a single event?</summary>
+
+You can add up to five hosts to one event. All selected hosts are added to the calendar invite so everyone stays in the loop.
+</details>
+
+<details>
+<summary>Do I need anything special to connect Microsoft Outlook/Teams?</summary>
+
+You’ll need to sign in with a Microsoft 365 account you control. Some organizations require an administrator to approve new app connections—if you see a consent prompt, contact your Microsoft admin to enable it.
+</details>
+
+<details>
+<summary>Which video link is used for multi‑host events?</summary>
+
+The conferencing provider set in the booking link is used. If Microsoft Teams is connected and selected for the link, a Teams meeting is created and included on the invite that all hosts and attendees receive.
 </details>
 
 

--- a/docusaurus/docs/crm/opportunities.md
+++ b/docusaurus/docs/crm/opportunities.md
@@ -55,6 +55,15 @@ To switch to the list view, click the `List` icon:
 3. Enter the opportunity details.
 4. Click `Create`.
 
+### Import opportunities (CSV)
+1. In `CRM` → `Opportunities`, click `Import`.
+2. Upload a CSV and map columns to opportunity fields.
+3. Optionally map associations to existing contacts or companies.
+4. Review choices, then finish the import.
+
+::::note
+Updating existing opportunities during import overwrites mapped fields on matching records (by ID or external ID). Export a backup first if you’re unsure.
+::::
 
 ## How to Edit an Opportunity
 
@@ -92,6 +101,10 @@ To switch to the list view, click the `List` icon:
 
 - Open the opportunity.
 - Change the `Stage` field to `Closed Won` or `Closed Lost`.
+
+::::info
+When marking an opportunity as `Closed Lost`, you may be prompted to provide a reason. Key stage changes (Won, Lost, Reopened) are recorded as activity notes for better history and reporting.
+::::
 
 ## How to Set Up a Pipeline
 ![Opportunities Pipeline View](./img/opportunities/pipeline-1.png)
@@ -190,6 +203,24 @@ Automation behavior:
 <summary>What is the currency for the opportunity amounts?</summary>
 
 The currency follows your Business App's configured currency settings.
+</details>
+
+<details>
+<summary>Can I import opportunities with CSV? What fields are supported?</summary>
+
+Yes. Go to `CRM` → `Opportunities` → `Import` and upload a CSV. You can map columns to standard fields (name, amount, stage, expected close date, owner, etc.) and to your custom fields. You can also map associations to existing contacts or companies.
+</details>
+
+<details>
+<summary>Will importing update existing opportunities?</summary>
+
+If you choose to update matches, rows that match by ID or external ID will overwrite the mapped fields on those records. Export a backup first if you’re unsure.
+</details>
+
+<details>
+<summary>Which automation actions are available for opportunities?</summary>
+
+You can create tasks, notes, and logged calls tied directly to an opportunity, update fields, and move an opportunity to a specific stage as part of an automation.
 </details>
 
 <details>


### PR DESCRIPTION
**Body**
Summary: Adds FAQs and cross-links for recently released Business App features.

**Scope:**
- crm/my-meetings.md: multi-host limit; Outlook/Teams connection; conferencing behavior
- crm/opportunities.md: CSV import fields; update behavior; automation actions available
- crm/contacts.md: owner via email mapping; import history/errors
- automations/index.md: “Get a response from an AI Employee” action
- ai/ai-workforce/ai-voice-receptionist.md: booking via connected calendar; link to My Meetings
- crm/activity-feed.md: delete meeting activities via related records
- administration/email_configuration.md: shared vs custom domain; HTTPS link branding note

**Notes:**
- Limited to released items only
- Cross-links verified