### PR TITLE
Wrap TOC with original component and inject page actions

### DIFF
--- a/docusaurus/src/theme/TOC/index.tsx
+++ b/docusaurus/src/theme/TOC/index.tsx
@@ -1,13 +1,16 @@
-import React from 'react';
+import React, {cloneElement, type ReactElement} from 'react';
 import OriginalTOC from '@theme-original/TOC';
-import PageActions from '@site/src/components/PageActions';
 import type {Props} from '@theme/TOC';
+import PageActions from '@site/src/components/PageActions';
 
-export default function TOCWrapper(props: Props) {
-  return (
+export default function TOCWrapper(props: Props): ReactElement {
+  const toc = <OriginalTOC {...props} />;
+  return cloneElement(
+    toc as ReactElement,
+    toc.props,
     <>
-      <OriginalTOC {...props} />
+      {toc.props.children}
       <PageActions />
-    </>
+    </>,
   );
 }


### PR DESCRIPTION
## Summary
- replace swizzled TOC with wrapper that clones the original component and appends page actions
- drop duplicated TOC stylesheet to rely on upstream styles

## Testing
- `npm test` (fails: Missing script "test")
- `cd docusaurus && npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68af17d1c2448323891d54090f5e341d