### PR TITLE
Wrap TOC with reusable PageActions

### DIFF
--- a/docusaurus/src/components/PageActions.module.css
+++ b/docusaurus/src/components/PageActions.module.css
@@ -4,6 +4,13 @@
   margin-top: 1rem;
 }
 
+.sticky {
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 1rem);
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
 .direction-column {
   flex-direction: column;
 }

--- a/docusaurus/src/theme/TOC/index.tsx
+++ b/docusaurus/src/theme/TOC/index.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import OriginalTOC from '@theme-original/TOC';
-import PageActions from '@site/src/components/PageActions';
+import TOC from '@theme-original/TOC';
+import withPageActions from '@site/src/components/withPageActions';
+import pageActionsStyles from '@site/src/components/PageActions.module.css';
 import type {Props} from '@theme/TOC';
 
-export default function TOCWrapper(props: Props) {
-  return (
-    <>
-      <OriginalTOC {...props} />
-      <PageActions />
-    </>
-  );
-}
+export default withPageActions<Props>(TOC, {
+  position: 'top',
+  direction: 'row',
+  align: 'end',
+  className: pageActionsStyles.sticky,
+});


### PR DESCRIPTION
## Summary
- Wrap original TOC component with withPageActions HOC instead of duplicating implementation
- Add sticky utility class so PageActions stay fixed while scrolling

## Testing
- `npm test` (fails: Missing script "test")
- `cd docusaurus && npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68af17d1c2448323891d54090f5e341d