### PR TITLE
nginx config to strip /docs/ from path and prevent absolute redirects

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,22 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
     gzip_min_length 1000;
 
+    # Redirect /docs/* to /* (remove /docs prefix)
+
+    # Prevent absolute redirects from including :8080
+    absolute_redirect off;
+    port_in_redirect off;
+
+    # Strip /docs prefix
+    location ~ ^/docs(/.*)$ {
+        return 302 $1;
+    }
+
+    # Redirect /docs to / (root)
+    # /docs -> /
+    location = /docs {
+        return 302 /;
+    
     # Main handler - serve files or fallback to index.html for SPA routing
     location / {
         try_files $uri /index.html;


### PR DESCRIPTION
Looks there are some links being served with /docs/. Adding some server-side redirects.