### PR TITLE
Fix "Set-up my Listing Widget"

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/connect-the-ai-receptionist-with-shopify.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/connect-the-ai-receptionist-with-shopify.md
@@ -525,7 +525,7 @@ Absolutely! Use these testing methods:
 
 **Tool Testing:** Review the "Explanation" feature in conversations to see raw API calls and responses
 
-**Channel Testing:** Test across different channels using the methods described in [AI Chat Receptionist setup](./index.md#test-and-monitor-your-ai-chat-receptionist) and [AI Voice Receptionist testing](../ai-voice-receptionist.md#test-and-monitor-your-ai-voice-receptionist)
+**Channel Testing:** Test across different channels using the methods described in [AI Chat Receptionist setup](./index.md#test-the-ai-chat-receptionists-responses) and [AI Voice Receptionist testing](../ai-voice-receptionist.md#test-and-monitor-your-ai-voice-receptionist)
 
 Always test thoroughly before enabling the capability for customer-facing interactions.
 </details>

--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/index.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/index.md
@@ -58,11 +58,11 @@ To respond accurately to general inquiries, your AI Chat Receptionist needs cont
 
  For a complete guide on providing your AI Employees with Knowledge, see the [Knowledge Sources section in the AI Workforce Overview](../ai_workforce_overview.md#knowledge-sources).
 
-## Preview your AI Chat Receptionist in Action
+## Preview your AI Chat Receptionist in Action {#test-the-ai-chat-receptionists-responses}
 
-Once your AI Chat Receptionist is set up, it's important to test how it handles real conversations and monitor its interactions over time. This helps you ensure the AI is answering questions accurately, capturing leads, and creating a positive experience for your website visitors. 
+Once your AI Chat Receptionist is set up, it's important to test how it handles real conversations and monitor its interactions over time. This helps you ensure the AI is answering questions accurately, capturing leads, and creating a positive experience for your website visitors. **For Partners**: This testing environment is also perfect for demonstrating the AI Chat Receptionist's capabilities to prospective clients during sales presentations.
 
-To test your AI Chat Receptionist before going live:
+To test your AI Chat Receptionist before going live (or to demo it to clients):
 
 1. **Navigate to the AI Workforce section**: Go to <AISparkleIcon /> `AI` > `AI Workforce` in your dashboard
 2. **Find your Chat Receptionist**: Locate the AI Chat Receptionist card in your workforce list

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -74,6 +74,20 @@ const config: Config = {
     ],
   ],
 
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          {
+            from: '/docs/ai/ai-workforce/ai-receptionist',
+            to: '/ai/ai-workforce/ai-chat-receptionist/',
+          },
+        ],
+      },
+    ],
+  ],
+
   themeConfig: {
       algolia: {
         // The application ID provided by Algolia

--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@docusaurus/core": "^3.8.1",
         "@docusaurus/faster": "^3.8.1",
+        "@docusaurus/plugin-client-redirects": "^3.8.1",
         "@docusaurus/preset-classic": "^3.8.1",
         "react-icons": "^5.5.0",
         "turndown": "^7.2.1"
@@ -3395,6 +3396,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.8.1.tgz",
+      "integrity": "sha512-F+86R7PBn6VNgy/Ux8w3ZRypJGJEzksbejQKlbTC8u6uhBUhfdXWkDp6qdOisIoW0buY5nLqucvZt1zNJzhJhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.8.1",
     "@docusaurus/faster": "^3.8.1",
+    "@docusaurus/plugin-client-redirects": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
     "react-icons": "^5.5.0",
     "turndown": "^7.2.1"


### PR DESCRIPTION
We had a link in a [VMF automation](https://partners.vendasta.com/automations/automation/Automation-5fc2b9d2-c3c5-406b-b293-92f8bda14744/workflow) that was [reported broken.](https://chat.google.com/room/AAAA4kRPZ8c/E1ebXrHgp3k/E1ebXrHgp3k?cls=10).

This adds the Docusaurus redirect plugin to help redirect that link to the correct heading and also adds a little more detail on the ideal "demo flow" for setting up the AI Chat Receptionist. 

The automation will change to point to the correct link, but this needs to capture the dozens of users who are still "caught" in that automation.