### PR TITLE
added google tag manager with cookiebot; specific event tagging done to work with Docusaurus as a SPA

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -33,6 +33,18 @@ const config: Config = {
         type: 'text/javascript',
       },
     },
+    // Google Tag Manager script (mirrors partnercenter-docs approach)
+    {
+      tagName: 'script',
+      attributes: {
+        type: 'text/javascript',
+      },
+      innerHTML: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${process.env.GTM_CONTAINER_ID || 'GTM-XXXXXXX'}');`,
+    },
   ],
 
   // Enable faster builds with Rspack bundler and persistent cache
@@ -55,12 +67,6 @@ const config: Config = {
     [
       'classic',
       {
-        // ← GA4 configuration
-        gtag: {
-          trackingID: 'G-1Y49QBYD4L',  // your GA4 Measurement ID
-          anonymizeIP: true,           // optional: set to false to disable
-        },
-  
         docs: {
           sidebarPath: './sidebars.ts',
           // Serve docs at site root so "/" shows the docs with sidebar
@@ -137,8 +143,19 @@ const config: Config = {
           title: 'Legal',
           items: [
             {
+              label: 'Privacy Policy',
+              to: '/legal/privacy-policy',
+            },
+            {
+              label: 'Terms of Use',
+              to: '/legal/terms',
+            },
+            {
               label: 'Cookie Declaration',
-              to: '/cookie-declaration',
+              to: '/legal/privacy-policy#cookie-declaration',
+            },
+            {
+              html: '<a href="#cookie-settings" data-cookie-settings-link>Cookie Settings</a>',
             },
           ],
         },

--- a/docusaurus/src/components/CookieDeclaration.tsx
+++ b/docusaurus/src/components/CookieDeclaration.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+
+export default function CookieDeclaration(): JSX.Element {
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.id = 'CookieDeclaration';
+    script.src = 'https://consent.cookiebot.com/18defc9c-f3d9-498d-b1d8-469fdf619133/cd.js';
+    script.type = 'text/javascript';
+    script.async = true;
+
+    const container = document.getElementById('cookie-declaration-container');
+    if (container) {
+      container.appendChild(script);
+    }
+
+    return () => {
+      const existingScript = document.getElementById('CookieDeclaration');
+      if (existingScript) existingScript.remove();
+    };
+  }, []);
+
+  return <div id="cookie-declaration-container" />;
+}
+
+

--- a/docusaurus/src/pages/cookie-declaration.tsx
+++ b/docusaurus/src/pages/cookie-declaration.tsx
@@ -1,33 +1,8 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import Layout from '@theme/Layout';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import CookieDeclaration from '../components/CookieDeclaration';
 
-export default function CookieDeclaration(): JSX.Element {
-  const { siteConfig } = useDocusaurusContext();
-
-  useEffect(() => {
-    // Create and append the Cookiebot declaration script
-    const script = document.createElement('script');
-    script.id = 'CookieDeclaration';
-    script.src = 'https://consent.cookiebot.com/18defc9c-f3d9-498d-b1d8-469fdf619133/cd.js';
-    script.type = 'text/javascript';
-    script.async = true;
-
-    // Find the container and append the script
-    const container = document.getElementById('cookie-declaration-container');
-    if (container) {
-      container.appendChild(script);
-    }
-
-    // Cleanup function to remove the script when component unmounts
-    return () => {
-      const existingScript = document.getElementById('CookieDeclaration');
-      if (existingScript) {
-        existingScript.remove();
-      }
-    };
-  }, []);
-
+export default function CookieDeclarationPage(): JSX.Element {
   return (
     <Layout
       title="Cookie Declaration"
@@ -42,9 +17,7 @@ export default function CookieDeclaration(): JSX.Element {
                 The declaration below is automatically updated by Cookiebot to reflect
                 the current cookie usage on our site.
               </p>
-              <div id="cookie-declaration-container">
-                {/* The Cookiebot declaration script will be injected here */}
-              </div>
+              <CookieDeclaration />
             </div>
           </div>
         </div>

--- a/docusaurus/src/pages/legal/privacy-policy.mdx
+++ b/docusaurus/src/pages/legal/privacy-policy.mdx
@@ -1,0 +1,31 @@
+---
+title: Privacy Policy
+description: Privacy Policy for the Business App documentation site
+---
+
+# Privacy Policy
+
+This documentation site ("Site") provides information about Business App. This Privacy Policy explains how this Site uses cookies and similar technologies and the limited data processed for analytics and performance.
+
+## Cookies and Consent
+
+This Site uses Cookiebot to manage cookie consent and to control when tags fire. You can review and update your consent at any time via the Cookie Settings link in the footer.
+
+<details id="cookie-declaration">
+<summary>View Cookie Declaration</summary>
+
+import CookieDeclaration from '../../components/CookieDeclaration';
+
+<CookieDeclaration />
+
+</details>
+
+## Analytics
+
+We use Google Tag Manager to deploy analytics tags, including Google Analytics 4 (GA4). Data is used in aggregate to improve Site content and navigation. IP anonymization may be enabled, and personal data is not used for profiling from this Site.
+
+## Contact
+
+If you have questions about this Privacy Policy, please contact the Business App team through your usual support channel.
+
+

--- a/docusaurus/src/pages/legal/terms.mdx
+++ b/docusaurus/src/pages/legal/terms.mdx
@@ -1,0 +1,14 @@
+---
+title: Terms of Use
+description: Terms of Use for the Business App documentation site
+---
+
+# Terms of Use
+
+These Terms of Use govern your access to and use of this documentation site ("Site"). The Site provides documentation and learning resources about Business App. By using the Site, you agree to these terms.
+
+The Site is provided "as is" without warranties of any kind. Content is provided for informational purposes and may change without notice.
+
+If you have questions about these Terms, please contact the Business App team through your usual support channel.
+
+

--- a/docusaurus/src/theme/Root.tsx
+++ b/docusaurus/src/theme/Root.tsx
@@ -1,0 +1,76 @@
+import React, {useEffect, useRef} from 'react';
+import {useLocation} from '@docusaurus/router';
+
+declare global {
+  interface Window {
+    dataLayer?: Array<Record<string, unknown>>;
+    Cookiebot?: { show?: () => void };
+  }
+}
+
+export default function Root({children}: {children: React.ReactNode}): React.ReactElement {
+  const location = useLocation();
+  const previousPathRef = useRef<string>('');
+
+  // Push pageview event to dataLayer on initial load and on every route change
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.dataLayer = window.dataLayer || [];
+
+    const page_path = `${location.pathname}${location.search}`;
+    const payload = {
+      event: 'pageview',
+      page_path,
+      page_title: typeof document !== 'undefined' ? document.title : '',
+      page_location: typeof window !== 'undefined' ? window.location.href : '',
+      previous_path: previousPathRef.current,
+      referrer: typeof document !== 'undefined' ? document.referrer : '',
+    };
+
+    window.dataLayer.push(payload);
+
+    // Update previous path for next navigation
+    previousPathRef.current = page_path;
+  }, [location.pathname, location.search]);
+
+  // Wire up Cookie Settings links
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+    const selector = '[data-cookie-settings-link]';
+    const elements = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>(selector),
+    );
+    const listeners = elements.map((element) => {
+      const handler = (event: MouseEvent) => {
+        event.preventDefault();
+        if (typeof window !== 'undefined' && window.Cookiebot?.show) {
+          window.Cookiebot.show();
+        }
+      };
+      element.addEventListener('click', handler);
+      return {element, handler};
+    });
+    return () => {
+      listeners.forEach(({element, handler}) => {
+        element.removeEventListener('click', handler);
+      });
+    };
+  }, [location.pathname, location.search]);
+
+  return (
+    <>
+      {/* Google Tag Manager (noscript) */}
+      <noscript>
+        <iframe
+          src={`https://www.googletagmanager.com/ns.html?id=${process.env.GTM_CONTAINER_ID || 'GTM-XXXXXXX'}`}
+          height="0"
+          width="0"
+          style={{display: 'none', visibility: 'hidden'}}
+        />
+      </noscript>
+      {children}
+    </>
+  );
+}
+
+


### PR DESCRIPTION
We did this on partnercenter-docs and it worked. Rolling out so that we use one single install approach (google tag manager) to make thing easy to manage.