### PR TITLE
Inline GTM container ID

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -43,7 +43,7 @@ const config: Config = {
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','${process.env.GTM_CONTAINER_ID || 'GTM-XXXXXXX'}');`,
+})(window,document,'script','dataLayer','GTM-1Y49QBYD4L');`,
     },
   ],
 

--- a/docusaurus/src/theme/Root.tsx
+++ b/docusaurus/src/theme/Root.tsx
@@ -11,7 +11,6 @@ declare global {
 export default function Root({children}: {children: React.ReactNode}): React.ReactElement {
   const location = useLocation();
   const previousPathRef = useRef<string>('');
-
   // Push pageview event to dataLayer on initial load and on every route change
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -62,7 +61,7 @@ export default function Root({children}: {children: React.ReactNode}): React.Rea
       {/* Google Tag Manager (noscript) */}
       <noscript>
         <iframe
-          src={`https://www.googletagmanager.com/ns.html?id=${process.env.GTM_CONTAINER_ID || 'GTM-XXXXXXX'}`}
+          src="https://www.googletagmanager.com/ns.html?id=GTM-1Y49QBYD4L"
           height="0"
           width="0"
           style={{display: 'none', visibility: 'hidden'}}


### PR DESCRIPTION
## Summary
- inline the Google Tag Manager container identifier directly in the Docusaurus head script
- hardcode the same GTM identifier in the Root theme component's noscript iframe and drop the customFields plumbing

## Testing
- npm run build (from `docusaurus/`; succeeds with existing broken-anchor warnings)


------
https://chatgpt.com/codex/tasks/task_b_68d559074d688323942163e1ed0f1739