### PR TITLE
Improved ChatGPT URL & Claude Context

### DIFF
--- a/docusaurus/src/components/PageActions.tsx
+++ b/docusaurus/src/components/PageActions.tsx
@@ -7,7 +7,71 @@ import GeminiLogo from '@site/static/img/gemini.svg';
 import GrokLogo from '@site/static/img/grok.svg';
 import {MdContentCopy} from 'react-icons/md';
 import TurndownService from 'turndown';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import siteConfig from '@generated/docusaurus.config';
 import styles from './PageActions.module.css';
+
+const CLAUDE_PROMPT_MAX_LENGTH = 7000;
+const GITHUB_DEFAULT_BRANCH = 'master';
+const SITE_DIRECTORY_IN_REPO = 'docusaurus';
+
+const {organizationName, projectName} = siteConfig;
+
+const GITHUB_BLOB_BASE_URL = `https://github.com/${organizationName}/${projectName}/blob/${GITHUB_DEFAULT_BRANCH}/`;
+const GITHUB_RAW_BASE_URL = `https://raw.githubusercontent.com/${organizationName}/${projectName}/${GITHUB_DEFAULT_BRANCH}/`;
+
+interface ClaudeSourceInfo {
+  repoPath: string;
+  blobUrl: string;
+  rawUrl: string;
+}
+
+const getArticleMarkdown = (): string => {
+  if (typeof window === 'undefined') return '';
+  const article = document.querySelector('article');
+  if (!article) return '';
+  const turndown = new TurndownService();
+  return turndown.turndown(article.innerHTML);
+};
+
+const toRepoPathFromSource = (source: string | undefined): ClaudeSourceInfo | null => {
+  if (!source) return null;
+  const withoutAlias = source.replace(/^@site\//, '');
+  const repoPath = withoutAlias.startsWith(`${SITE_DIRECTORY_IN_REPO}/`)
+    ? withoutAlias
+    : `${SITE_DIRECTORY_IN_REPO}/${withoutAlias}`;
+  return {
+    repoPath,
+    blobUrl: `${GITHUB_BLOB_BASE_URL}${repoPath}`,
+    rawUrl: `${GITHUB_RAW_BASE_URL}${repoPath}`
+  };
+};
+
+const buildClaudePrompt = ({
+  pageUrl,
+  markdown,
+  sourceInfo
+}: {
+  pageUrl: string;
+  markdown: string;
+  sourceInfo: ClaudeSourceInfo | null;
+}): string => {
+  const basePrompt = `You are assisting me with the Business App documentation page at ${pageUrl}. Summarize the content and be prepared to answer follow-up questions.`;
+
+  if (markdown) {
+    const sectionHeader = '\n\n---\nPage content (Markdown):\n';
+    const fullPrompt = `${basePrompt}${sectionHeader}${markdown}`;
+    if (fullPrompt.length <= CLAUDE_PROMPT_MAX_LENGTH) {
+      return fullPrompt;
+    }
+  }
+
+  if (sourceInfo) {
+    return `${basePrompt}\n\nThe entire Markdown source for this page is publicly available here:\n${sourceInfo.rawUrl}\n\n(Readable GitHub view: ${sourceInfo.blobUrl})\n\nPlease reference that file so you have the full content before helping me.`;
+  }
+
+  return `${basePrompt}\n\nThe full content could not be embedded automatically. Please reference the page directly if you need additional details.`;
+};
 
 interface PageActionsProps {
   className?: string;
@@ -21,6 +85,8 @@ export default function PageActions({
   align = 'start'
 }: PageActionsProps): ReactNode {
   const [copied, setCopied] = useState(false);
+  const docContext = useDoc();
+  const claudeSourceInfo = toRepoPathFromSource(docContext?.metadata?.source);
 
   const getPrompt = () => {
     if (typeof window === 'undefined') return '';
@@ -37,7 +103,13 @@ export default function PageActions({
 
   const handleOpenClaude = () => {
     if (typeof window === 'undefined') return;
-    const prompt = getPrompt();
+    const pageUrl = window.location.href;
+    const markdown = getArticleMarkdown();
+    const prompt = buildClaudePrompt({
+      pageUrl,
+      markdown,
+      sourceInfo: claudeSourceInfo
+    });
     const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(prompt)}`;
     window.open(claudeUrl, '_blank');
   };
@@ -65,10 +137,8 @@ export default function PageActions({
 
   const handleCopyMarkdown = async () => {
     if (typeof window === 'undefined') return;
-    const article = document.querySelector('article');
-    if (!article) return;
-    const turndown = new TurndownService();
-    const markdown = turndown.turndown(article.innerHTML);
+    const markdown = getArticleMarkdown();
+    if (!markdown) return;
     try {
       await navigator.clipboard.writeText(markdown);
       setCopied(true);
@@ -79,7 +149,7 @@ export default function PageActions({
   };
 
   return (
-    <div 
+    <div
       className={clsx(
         styles.pageActions,
         styles[`direction-${direction}`],

--- a/docusaurus/src/components/PageActions.tsx
+++ b/docusaurus/src/components/PageActions.tsx
@@ -31,7 +31,7 @@ export default function PageActions({
   const handleOpenChatGPT = () => {
     if (typeof window === 'undefined') return;
     const prompt = getPrompt();
-    const chatUrl = `https://chat.openai.com/share/new?prompt=${encodeURIComponent(prompt)}`;
+    const chatUrl = `https://chatgpt.com/?q=${encodeURIComponent(prompt)}`;
     window.open(chatUrl, '_blank');
   };
 


### PR DESCRIPTION
- Previous PR had a malformed URL to open the prompt in ChatGPT. This new one should work across most browser implementations.
- Claude's `web_fetch` tool is not able to fetch Javascript...which is the majority of how content is loaded in Docusaurus. Instead, created a short function that finds the raw Github content and uses that as the source.