### PR TITLE
docs(ai-chat): clarify model disclosure and data usage for AI Chat Receptionist

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/model-and-data-faq.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/model-and-data-faq.md
@@ -1,0 +1,79 @@
+---
+title: AI Chat Receptionist – model and data FAQ
+sidebar_label: Model and data FAQ
+description: Answers to common questions about the AI Chat Receptionist models, data sources, and how to get the best results.
+tags: [ai, ai-workforce, ai-chat-receptionist, faq]
+keywords: [ai-chat, receptionist, models, data-sources, privacy, knowledge-base]
+---
+
+## What is this page?
+This page answers common questions about the technology that powers the AI Chat Receptionist and how your data is used. It also shares practical tips to improve responses.
+
+## Why is this important?
+Clear expectations help you set up the AI Chat Receptionist correctly, protect customer data, and get accurate answers for your business.
+
+## What’s included
+- Guidance on the underlying models
+- How the assistant uses your content
+- Data-handling notes
+- Tips to improve response quality
+- Frequently asked questions
+
+:::warning
+Specific provider names and model versions are not disclosed and may change without notice. The service selects safe, high‑quality models based on performance, reliability, and cost.
+:::
+
+## Frequently asked questions (FAQs)
+
+<details>
+<summary>What AI model powers the AI Chat Receptionist?</summary>
+The AI Chat Receptionist uses industry‑standard large language models (LLMs). Specific model names and versions are not fixed or publicly listed, and they may change over time to improve quality and reliability.
+</details>
+
+<details>
+<summary>Does the model train on my conversations?</summary>
+Conversations are processed to provide the service and improve quality and safety. The assistant relies on the knowledge you connect or add. Avoid sharing sensitive information in conversations or the knowledge base unless you are comfortable storing it.
+</details>
+
+<details>
+<summary>Where do the assistant’s answers come from?</summary>
+Answers come from the LLM combined with your connected knowledge base and the instructions you configure. Keep this content accurate and up to date for the best results.
+</details>
+
+<details>
+<summary>Can I force the system to use a specific provider or model?</summary>
+No. The underlying models are managed by the service to ensure consistent performance and safety across all accounts.
+</details>
+
+<details>
+<summary>How do I improve answer accuracy?</summary>
+- Add clear, current information to your knowledge base
+- Provide step‑by‑step answers and examples your customers commonly need
+- Remove outdated or conflicting content
+- Test with real questions and refine your instructions
+</details>
+
+<details>
+<summary>What types of content work best in the knowledge base?</summary>
+Short, factual articles with clear headings, hours, pricing rules, policies, and product or service details work best. Use simple language and avoid long narratives.
+</details>
+
+<details>
+<summary>Can I upload private or sensitive information?</summary>
+Only add information you are comfortable storing and using to answer customer questions. Do not include secrets, passwords, or payment details.
+</details>
+
+<details>
+<summary>Does the assistant follow my business tone and rules?</summary>
+Yes. Provide tone and policy guidelines in your instructions and knowledge base. The assistant uses these as context when crafting replies.
+</details>
+
+<details>
+<summary>What happens if the assistant is not confident?</summary>
+When information is missing or unclear, the assistant may ask follow‑up questions or suggest contacting your team. Add the missing details to your knowledge base to reduce these cases.
+</details>
+
+<details>
+<summary>Where can I learn more about connecting a knowledge base?</summary>
+See the setup guide: [Build a knowledge base](../../knowledge-base.md)
+</details>


### PR DESCRIPTION
Summary
- Adds a new FAQ page under AI Workforce > AI Chat Receptionist that clarifies:
  - Underlying AI models are not fixed or publicly disclosed and may change over time
  - How the assistant uses your connected knowledge base and instructions
  - Practical guidance to improve responses and handle data safely

Why
A recent support thread showed conflicting answers about the exact AI model powering the AI Chat channel. The correct guidance is that specific model names/versions are not disclosed and can change. This PR updates the Business App Help with a concise, user‑friendly FAQ to prevent misinformation.

Change details
- New page: docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/model-and-data-faq.md
- Includes 10 FAQs, a warning block about model disclosure, and a link to the knowledge base setup page

Notes
- No UI or future‑state claims were added
- Uses Docusaurus‑compatible Markdown and follows the Help Center style guidelines
