### PR TITLE
Add mobile-friendly product switcher to doc sidebar

### DIFF
--- a/docusaurus/src/components/ProductSwitcher.module.css
+++ b/docusaurus/src/components/ProductSwitcher.module.css
@@ -94,7 +94,7 @@
 .mobileSwitcherButton {
   width: 100%;
   justify-content: flex-start;
-  align-items: flex-start;
+  align-items: center;
   gap: 12px;
 }
 
@@ -131,6 +131,11 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+}
+
+.mobileSwitcherButton .chevron {
+  align-self: center;
+  margin-top: 0;
 }
 
 .chevron {

--- a/docusaurus/src/components/ProductSwitcher.module.css
+++ b/docusaurus/src/components/ProductSwitcher.module.css
@@ -76,21 +76,26 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 12px;
+  padding: clamp(6px, 0.6vw, 10px) clamp(12px, 1.2vw, 18px);
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: 6px;
   background: var(--ifm-background-color);
   color: var(--ifm-font-color-base);
   cursor: pointer;
-  font-size: 14px;
+  font-size: clamp(14px, 1.2vw, 16px);
   font-weight: 500;
+  font-family: var(--ifm-font-family-base);
+  line-height: 1.25;
   transition: all 0.2s ease;
-  height: 36px;
+  min-height: 36px;
+  height: auto;
 }
 
 .mobileSwitcherButton {
   width: 100%;
-  justify-content: space-between;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 12px;
 }
 
 .switcherButton:hover {
@@ -102,18 +107,37 @@
   width: 20px;
   height: 20px;
   object-fit: contain;
+  flex-shrink: 0;
 }
 
 .productName {
-  max-width: 150px;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: none;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-weight: 600;
+  font-family: var(--ifm-font-family-base);
+  letter-spacing: -0.01em;
+}
+
+.mobileSwitcherButton .productName {
+  max-width: none;
+  white-space: normal;
+  overflow: visible;
+  text-overflow: initial;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .chevron {
   transition: transform 0.2s ease;
   color: var(--ifm-color-emphasis-600);
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .chevronOpen {
@@ -165,7 +189,7 @@
   align-items: center;
   gap: 12px;
   width: 100%;
-  padding: 12px 16px;
+  padding: clamp(10px, 0.9vw, 14px) clamp(16px, 1.3vw, 22px);
   border: none;
   background: transparent;
   color: var(--ifm-font-color-base);
@@ -195,13 +219,13 @@
 }
 
 .dropdownItemName {
-  font-size: 14px;
+  font-size: clamp(14px, 1.1vw, 16px);
   font-weight: 500;
   margin-bottom: 2px;
 }
 
 .dropdownItemTagline {
-  font-size: 12px;
+  font-size: clamp(12px, 0.95vw, 13px);
   color: var(--ifm-color-emphasis-700);
   /* Allow multi-line, clamp to two lines with an ellipsis */
   display: -webkit-box;
@@ -230,12 +254,37 @@
   }
 
   .productName {
-    max-width: 100px;
+    max-width: none;
+    width: 100%;
   }
   
   .mobileVariant .dropdown,
   .sidebarVariant .dropdown {
     min-width: unset;
     width: 100%;
+  }
+}
+
+@media (min-width: 1200px) {
+  .switcherButton {
+    font-weight: 600;
+    border-radius: 8px;
+  }
+
+  .sidebarSwitcherButton {
+    padding: 14px 18px;
+  }
+
+  .dropdownItem {
+    gap: 16px;
+  }
+
+  .dropdownItemName {
+    font-weight: 600;
+  }
+
+  .dropdownLogo {
+    width: 36px;
+    height: 36px;
   }
 }

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -282,3 +282,33 @@
 .navbar__inner {
   justify-content: flex-start;
 }
+
+/* Give the mobile sidebar brand row breathing room */
+.navbar-sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 1.2rem 0.6rem;
+}
+
+.navbar-sidebar__brand .navbar__brand {
+  margin-right: 0;
+  flex: 1;
+  min-width: 0;
+}
+
+.navbar-sidebar__brand .navbar__title.text--truncate {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: initial;
+  line-height: 1.3;
+}
+
+.navbar-sidebar__brand .navbar-sidebar__close {
+  margin-left: 0.25rem;
+  border-radius: 999px;
+  padding: 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -282,33 +282,3 @@
 .navbar__inner {
   justify-content: flex-start;
 }
-
-/* Give the mobile sidebar brand row breathing room */
-.navbar-sidebar__brand {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.8rem 1.2rem 0.6rem;
-}
-
-.navbar-sidebar__brand .navbar__brand {
-  margin-right: 0;
-  flex: 1;
-  min-width: 0;
-}
-
-.navbar-sidebar__brand .navbar__title.text--truncate {
-  white-space: normal;
-  overflow: visible;
-  text-overflow: initial;
-  line-height: 1.3;
-}
-
-.navbar-sidebar__brand .navbar-sidebar__close {
-  margin-left: 0.25rem;
-  border-radius: 999px;
-  padding: 0.35rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}

--- a/docusaurus/src/theme/DocSidebar/Mobile/index.tsx
+++ b/docusaurus/src/theme/DocSidebar/Mobile/index.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  NavbarSecondaryMenuFiller,
+  type NavbarSecondaryMenuComponent,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
+import DocSidebarItems from '@theme/DocSidebarItems';
+import type {Props} from '@theme/DocSidebar/Mobile';
+
+import ProductSwitcher from '@site/src/components/ProductSwitcher';
+import styles from './styles.module.css';
+
+const DocSidebarMobileSecondaryMenu: NavbarSecondaryMenuComponent<Props> = ({
+  sidebar,
+  path,
+}) => {
+  const mobileSidebar = useNavbarMobileSidebar();
+
+  return (
+    <>
+      <div className={styles.switcherContainer}>
+        <ProductSwitcher variant="mobile" />
+      </div>
+
+      <ul
+        className={clsx(
+          ThemeClassNames.docs.docSidebarMenu,
+          'menu__list',
+          styles.menuList,
+        )}
+      >
+        <DocSidebarItems
+          items={sidebar}
+          activePath={path}
+          onItemClick={(item) => {
+            if (item.type === 'category' && item.href) {
+              mobileSidebar.toggle();
+            }
+            if (item.type === 'link') {
+              mobileSidebar.toggle();
+            }
+          }}
+          level={1}
+        />
+      </ul>
+    </>
+  );
+};
+
+function DocSidebarMobile(props: Props) {
+  return (
+    <NavbarSecondaryMenuFiller
+      component={DocSidebarMobileSecondaryMenu}
+      props={props}
+    />
+  );
+}
+
+export default React.memo(DocSidebarMobile);

--- a/docusaurus/src/theme/DocSidebar/Mobile/styles.module.css
+++ b/docusaurus/src/theme/DocSidebar/Mobile/styles.module.css
@@ -1,5 +1,5 @@
 .switcherContainer {
-  padding: 0.75rem 1rem 0.5rem;
+  padding: 0.4rem 1rem 0.5rem;
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
   background: var(--ifm-background-surface-color);
 }

--- a/docusaurus/src/theme/DocSidebar/Mobile/styles.module.css
+++ b/docusaurus/src/theme/DocSidebar/Mobile/styles.module.css
@@ -1,0 +1,15 @@
+.switcherContainer {
+  padding: 0.75rem 1rem 0.5rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-background-surface-color);
+}
+
+.menuList {
+  padding: 0.25rem 0;
+}
+
+@media (min-width: 997px) {
+  .switcherContainer {
+    display: none;
+  }
+}

--- a/docusaurus/src/theme/Navbar/MobileSidebar/Header/index.tsx
+++ b/docusaurus/src/theme/Navbar/MobileSidebar/Header/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
+import {translate} from '@docusaurus/Translate';
+import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle';
+import IconClose from '@theme/Icon/Close';
+import NavbarLogo from '@theme/Navbar/Logo';
+
+import styles from './styles.module.css';
+
+function CloseButton() {
+  const mobileSidebar = useNavbarMobileSidebar();
+  return (
+    <button
+      type="button"
+      aria-label={translate({
+        id: 'theme.docs.sidebar.closeSidebarButtonAriaLabel',
+        message: 'Close navigation bar',
+        description: 'The ARIA label for close button of mobile sidebar',
+      })}
+      className={clsx('clean-btn', 'navbar-sidebar__close', styles.closeButton)}
+      onClick={() => mobileSidebar.toggle()}
+    >
+      <IconClose color="var(--ifm-color-emphasis-600)" />
+    </button>
+  );
+}
+
+export default function NavbarMobileSidebarHeader() {
+  return (
+    <div className={styles.mobileHeader}>
+      <NavbarLogo />
+      <div className={styles.actions}>
+        <NavbarColorModeToggle className={styles.colorToggle} />
+        <CloseButton />
+      </div>
+    </div>
+  );
+}

--- a/docusaurus/src/theme/Navbar/MobileSidebar/Header/styles.module.css
+++ b/docusaurus/src/theme/Navbar/MobileSidebar/Header/styles.module.css
@@ -1,0 +1,57 @@
+.mobileHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 0.75rem;
+  row-gap: 0.35rem;
+  padding: 0.8rem 1.2rem 0.4rem;
+  flex-wrap: wrap;
+}
+
+.mobileHeader :global(.navbar__brand) {
+  margin-right: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.mobileHeader :global(.navbar__title.text--truncate) {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: initial;
+  line-height: 1.3;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.colorToggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.1rem;
+}
+
+.colorToggle :global(.toggle) {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.closeButton {
+  border-radius: 999px;
+  padding: 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 420px) {
+  .actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}


### PR DESCRIPTION
## Summary
- add a swizzled mobile doc sidebar that surfaces the product switcher component
- style the mobile sidebar switcher container so it fills the available width and separates from nav links

## Testing
- npm run build *(warnings about pre-existing duplicate routes and broken anchors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691667d401f88323a2c6f289dec59dec)