### PR TITLE
Fix 404 links on Wordpress Hosting homepage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Project Rules & Context
+
+## Documentation URL Structure
+- **General Rule**:
+  - Rely on Docusaurus's default file-system routing whenever possible.
+  - Avoid manually defining `slug` in `_category_.json` unless strictly necessary (e.g., for legacy redirects or special marketing URLs).
+  - Use **relative links** (e.g., `to="./overview"`) in markdown files. This ensures links remain valid even if the parent directory is moved, provided the relative structure stays the same.
+
+## WordPress Hosting Specifics
+- The `wordpress-hosting` section follows a specific URL pattern for category indices.
+- Pages are located in `docs/wordpress-hosting/`.
+- **Category Index Pages**: You MUST manually define a `slug` in `_category_.json` for all subdirectories.
+  - Pattern: `/wordpress-hosting/category/{dirname}` (e.g., `/wordpress-hosting/category/overview`).
+  - This ensures a consistent URL structure for category landing pages.

--- a/docusaurus/docs/wordpress-hosting/advanced-tools/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/advanced-tools/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Developer utilities, logs, and configuration for advanced use cases.",
-    "slug": "/wordpress-hosting/advanced-tools"
+    "slug": "/wordpress-hosting/category/advanced-tools"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/advanced-tools/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/advanced-tools/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Developer utilities, logs, and configuration for advanced use cases.",
-    "slug": "/advanced-tools"
+    "slug": "/wordpress-hosting/advanced-tools"
   }
-} 
+}

--- a/docusaurus/docs/wordpress-hosting/analytics/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/analytics/_category_.json
@@ -5,7 +5,7 @@
   "collapsed": true,
   "link": {
     "type": "generated-index",
-    "description": "Analytics for your website.",
-    "slug": "/wordpress-hosting/analytics"
+    "description": "View and understand your WordPress site analytics.",
+    "slug": "/wordpress-hosting/category/analytics"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/analytics/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/analytics/_category_.json
@@ -1,12 +1,11 @@
 {
-    "label": "Analytics",
-    "position": 5,
-    "collapsible": true,
-    "collapsed": true,
-    "link": {
-      "type": "generated-index",
-      "description": "Analytics for your website.",
-      "slug": "/analytics"
-    }
+  "label": "Analytics",
+  "position": 5,
+  "collapsible": true,
+  "collapsed": true,
+  "link": {
+    "type": "generated-index",
+    "description": "Analytics for your website.",
+    "slug": "/wordpress-hosting/analytics"
+  }
 }
-  

--- a/docusaurus/docs/wordpress-hosting/backups/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/backups/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Protect your work and restore your website when needed.",
-    "slug": "/backups"
+    "slug": "/wordpress-hosting/backups"
   }
-} 
+}

--- a/docusaurus/docs/wordpress-hosting/backups/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/backups/_category_.json
@@ -5,7 +5,7 @@
   "collapsed": true,
   "link": {
     "type": "generated-index",
-    "description": "Protect your work and restore your website when needed.",
-    "slug": "/wordpress-hosting/backups"
+    "description": "Manage backups for your WordPress site.",
+    "slug": "/wordpress-hosting/category/backups"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/domains/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/domains/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Domain setup and management",
-    "slug": "/wordpress-hosting/domains"
+    "slug": "/wordpress-hosting/category/domains"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/domains/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/domains/_category_.json
@@ -1,12 +1,11 @@
 {
-    "label": "Domains",
-    "position": 6,
-    "collapsible": true,
-    "collapsed": true,
-    "link": {
-      "type": "generated-index",
-      "description": "Domain setup and management",
-      "slug": "/domains"
-    }
+  "label": "Domains",
+  "position": 6,
+  "collapsible": true,
+  "collapsed": true,
+  "link": {
+    "type": "generated-index",
+    "description": "Domain setup and management",
+    "slug": "/wordpress-hosting/domains"
+  }
 }
-  

--- a/docusaurus/docs/wordpress-hosting/email-history/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/email-history/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Troubleshoot outgoing email and delivery from your site.",
-    "slug": "/email-history"
+    "slug": "/wordpress-hosting/email-history"
   }
-} 
+}

--- a/docusaurus/docs/wordpress-hosting/email-history/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/email-history/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Troubleshoot outgoing email and delivery from your site.",
-    "slug": "/wordpress-hosting/email-history"
+    "slug": "/wordpress-hosting/category/email-history"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/faqs/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/faqs/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Quick answers to common questions.",
-    "slug": "/wordpress-hosting/faqs"
+    "slug": "/wordpress-hosting/category/faqs"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/faqs/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/faqs/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Quick answers to common questions.",
-    "slug": "/faqs"
+    "slug": "/wordpress-hosting/faqs"
   }
-} 
+}

--- a/docusaurus/docs/wordpress-hosting/general/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/general/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Account and platform basics to help you manage your site.",
-    "slug": "/general"
+    "slug": "/wordpress-hosting/general"
   }
-} 
+}

--- a/docusaurus/docs/wordpress-hosting/general/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/general/_category_.json
@@ -5,7 +5,7 @@
   "collapsed": true,
   "link": {
     "type": "generated-index",
-    "description": "Account and platform basics to help you manage your site.",
-    "slug": "/wordpress-hosting/general"
+    "description": "General settings and configurations for WordPress hosting.",
+    "slug": "/wordpress-hosting/category/general"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/import/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/import/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Bring an existing site into WordPress Hosting.",
-    "slug": "/import"
+    "slug": "/wordpress-hosting/import"
   }
-} 
+}

--- a/docusaurus/docs/wordpress-hosting/import/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/import/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Bring an existing site into WordPress Hosting.",
-    "slug": "/wordpress-hosting/import"
+    "slug": "/wordpress-hosting/category/import"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/index.mdx
+++ b/docusaurus/docs/wordpress-hosting/index.mdx
@@ -12,7 +12,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
 
 <div className="row">
   <div className="col col--4">
-    <Link className="card-link" to="./overview">
+    <Link className="card-link" to="/wordpress-hosting/category/overview">
       <div className="card">
         <div className="card__header">
           <h3>Overview</h3>
@@ -25,7 +25,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./general">
+    <Link className="card-link" to="/wordpress-hosting/category/general">
       <div className="card">
         <div className="card__header">
           <h3>General</h3>
@@ -38,7 +38,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./wordpress-dashboard">
+    <Link className="card-link" to="/wordpress-hosting/category/wordpress-dashboard">
       <div className="card">
         <div className="card__header">
           <h3>WordPress Dashboard</h3>
@@ -51,7 +51,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./analytics">
+    <Link className="card-link" to="/wordpress-hosting/category/analytics">
       <div className="card">
         <div className="card__header">
           <h3>Analytics</h3>
@@ -64,7 +64,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./domains">
+    <Link className="card-link" to="/wordpress-hosting/category/domains">
       <div className="card">
         <div className="card__header">
           <h3>Domains</h3>
@@ -77,7 +77,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./import">
+    <Link className="card-link" to="/wordpress-hosting/category/import">
       <div className="card">
         <div className="card__header">
           <h3>Import</h3>
@@ -90,7 +90,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./backups">
+    <Link className="card-link" to="/wordpress-hosting/category/backups">
       <div className="card">
         <div className="card__header">
           <h3>Backups</h3>
@@ -103,7 +103,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./staging">
+    <Link className="card-link" to="/wordpress-hosting/category/staging">
       <div className="card">
         <div className="card__header">
           <h3>Staging</h3>
@@ -116,7 +116,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./templates">
+    <Link className="card-link" to="/wordpress-hosting/category/templates">
       <div className="card">
         <div className="card__header">
           <h3>Templates</h3>
@@ -129,7 +129,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./email-history">
+    <Link className="card-link" to="/wordpress-hosting/category/email-history">
       <div className="card">
         <div className="card__header">
           <h3>Email History</h3>
@@ -142,7 +142,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./faqs">
+    <Link className="card-link" to="/wordpress-hosting/category/faqs">
       <div className="card">
         <div className="card__header">
           <h3>FAQs</h3>
@@ -155,7 +155,7 @@ This documentation helps you launch, manage, and grow your WordPress websites wi
   </div>
 
   <div className="col col--4">
-    <Link className="card-link" to="./advanced-tools">
+    <Link className="card-link" to="/wordpress-hosting/category/advanced-tools">
       <div className="card">
         <div className="card__header">
           <h3>Advanced Tools</h3>

--- a/docusaurus/docs/wordpress-hosting/overview/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/overview/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Start here for key concepts and getting started resources.",
-    "slug": "/overview"
+    "slug": "/wordpress-hosting/overview"
   }
-} 
+}

--- a/docusaurus/docs/wordpress-hosting/overview/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/overview/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Start here for key concepts and getting started resources.",
-    "slug": "/wordpress-hosting/overview"
+    "slug": "/wordpress-hosting/category/overview"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/staging/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/staging/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Test changes safely before publishing them live.",
-    "slug": "/staging"
+    "slug": "/wordpress-hosting/staging"
   }
-} 
+}

--- a/docusaurus/docs/wordpress-hosting/staging/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/staging/_category_.json
@@ -5,7 +5,7 @@
   "collapsed": true,
   "link": {
     "type": "generated-index",
-    "description": "Test changes safely before publishing them live.",
-    "slug": "/wordpress-hosting/staging"
+    "description": "Set up and manage staging environments.",
+    "slug": "/wordpress-hosting/category/staging"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/templates/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/templates/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Use professionally designed layouts to build faster.",
-    "slug": "/templates"
+    "slug": "/wordpress-hosting/templates"
   }
-} 
+}

--- a/docusaurus/docs/wordpress-hosting/templates/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/templates/_category_.json
@@ -5,7 +5,7 @@
   "collapsed": true,
   "link": {
     "type": "generated-index",
-    "description": "Use professionally designed layouts to build faster.",
-    "slug": "/wordpress-hosting/templates"
+    "description": "Manage templates for your WordPress site.",
+    "slug": "/wordpress-hosting/category/templates"
   }
 }

--- a/docusaurus/docs/wordpress-hosting/wordpress-dashboard/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/wordpress-dashboard/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Everything inside WordPress: pages, plugins, themes, and more.",
-    "slug": "/wordpress-dashboard"
+    "slug": "/wordpress-hosting/wordpress-dashboard"
   }
-} 
+}

--- a/docusaurus/docs/wordpress-hosting/wordpress-dashboard/_category_.json
+++ b/docusaurus/docs/wordpress-hosting/wordpress-dashboard/_category_.json
@@ -6,6 +6,6 @@
   "link": {
     "type": "generated-index",
     "description": "Everything inside WordPress: pages, plugins, themes, and more.",
-    "slug": "/wordpress-hosting/wordpress-dashboard"
+    "slug": "/wordpress-hosting/category/wordpress-dashboard"
   }
 }


### PR DESCRIPTION
Right now, Wordpress-Hosting is using a different documentation structure for it's homepage. While we need to change these, in the meantime we need the URLs to follow the same predictable path and make those homepage cards work. Should be fixed!