### PR TITLE
Add review sync timing documentation to Reputation Management

### DIFF
--- a/docusaurus/docs/reputation-management/reviews/respond-to-reviews.mdx
+++ b/docusaurus/docs/reputation-management/reviews/respond-to-reviews.mdx
@@ -36,6 +36,36 @@ You may encounter an error message when attempting to respond to a Google review
 
 *Note: We attempted to include an image here, but the image could not be retrieved from the external source.*
 
+## How Long Does It Take for Reviews to Appear?
+
+Review sync timing depends on whether the review source is monitored or directly connected through an API.
+
+### Monitored Review Sources (Not Connected)
+
+For review platforms like Google and Facebook that are not connected, the platform checks for new reviews and typically imports them within **24 hours** of being posted.
+
+- These sources are polled regularly  
+- There is no direct API connection
+
+### Connected Review Sources (Direct Integrations)
+
+Certain review sources offer faster syncing when connected through secure APIs:
+
+#### Google Business Profile (Connected)
+
+- Reviews usually sync within **2 hours** after posting  
+- Timing depends on when Google releases new review data
+
+#### Facebook Pages (Connected)
+
+- Reviews and recommendations usually sync within **10 minutes**  
+- Based on Facebook’s data release timing
+
+### My Listing (Internal Review Source)
+
+- Reviews submitted through My Listing appear **immediately**  
+- Managed entirely within the platform and do not require syncing
+
 ## FAQs
 
 <details>
@@ -53,10 +83,4 @@ Google, Facebook, TripAdvisor, BBB, Booking.com, Expedia, Trustpilot, Yelp, A Pl
 <summary>Can I respond to all review resources directly in the product?</summary>
 
 You can respond to Facebook and Google reviews directly within our user-friendly interface, making it quick and straightforward. For other review sources, we've designed a convenient process. You can effortlessly draft your responses within the Reputation Management Product. Once you're satisfied with your message, a simple click takes you to the source platform, where you can easily copy and paste your prepped response.
-</details>
-
-<details>
-<summary>How long does it take for Google and Facebook reviews to appear in Reputation Management?</summary>
-
-Once Facebook and Google Business Profile accounts are connected, reviews (including historical reviews) from these sources will pull in almost immediately. After this, Reputation Management scrapes for reviews once per 24-hour period.
 </details>


### PR DESCRIPTION
- Added comprehensive section explaining how long reviews take to appear
- Covered monitored vs connected review sources
- Detailed timing for Google Business Profile (2 hours when connected)
- Detailed timing for Facebook Pages (10 minutes when connected)
- Explained immediate appearance for My Listing reviews
- Clarified 24-hour sync timing for non-connected sources