### PR TITLE
Add setup video to Inside Sales Representative page

### DIFF
--- a/docusaurus/docs/business-app/ai/ai-workforce/custom-ai-employees/inside-sales-representative.mdx
+++ b/docusaurus/docs/business-app/ai/ai-workforce/custom-ai-employees/inside-sales-representative.mdx
@@ -18,6 +18,30 @@ keywords:
 
 The Inside Sales Representative is a custom AI Employee that handles inbound customer inquiries with a sales-first mindset. Rather than simply collecting contact details, it qualifies leads first: confirming the business can actually serve the customer's need before capturing their information. Qualified leads get booked into appointments, and the AI answers service and pricing questions using your knowledge base. Unqualified leads are handled gracefully without wasting the sales team's time.
 
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/xylk08ufqi?web_component=true&seo=true"
+      title="AI Inside Sales Representative Setup"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
+
 ## Why build an Inside Sales Representative?
 
 When you need a dedicated sales-qualification role, one that actively confirms the business can serve a customer before capturing their details, a custom AI Employee built for sales gives you that control. Without lead qualification, sales teams often end up chasing inquiries that aren't a good fit, or booking appointments that don't convert.


### PR DESCRIPTION
Adds a Wistia walkthrough video demonstrating how to set up the AI Inside Sales Representative. Converted file from .md to .mdx to support video embedding.