### PR TITLE
docs: update CalendarHero SMS integration — mark as discontinued for …

### DIFF
--- a/docusaurus/docs/calendarhero/setting-up-calendarhero/how-do-i-setup-sms.md
+++ b/docusaurus/docs/calendarhero/setting-up-calendarhero/how-do-i-setup-sms.md
@@ -3,9 +3,10 @@ title: How do I setup SMS?
 sidebar_position: 7
 ---
 
-To activate your CalendarHero automated assistant on SMS, all you need to do is send a text with the word "Hi" or "Hello" to one of the following numbers and follow the instructions. 
+:::warning SMS integration has been discontinued
 
+New SMS integrations with CalendarHero are no longer available. If you already have SMS connected to your account, your existing integration will continue to work. However, no new SMS connections can be added.
 
-It will be the same process as activating your assistant on any of the other messengers it is available on. You can also access [https://calendarhero.com/sms](https://calendarhero.com/sms) for all the numbers.  
-  
-To manage or remove your current SMS connection please go to your platform list here: [https://app.calendarhero.com/settings/accounts/list#messenger](https://app.calendarhero.com/settings/accounts/list#messenger)
+:::
+
+If you currently have SMS integrated with CalendarHero, you can manage or remove your connection from your platform list here: [https://app.calendarhero.com/settings/accounts/list#messenger](https://app.calendarhero.com/settings/accounts/list#messenger)

--- a/docusaurus/docs/calendarhero/setting-up-calendarhero/what-platforms-does-calendarhero-work-with.md
+++ b/docusaurus/docs/calendarhero/setting-up-calendarhero/what-platforms-does-calendarhero-work-with.md
@@ -36,7 +36,7 @@ CalendarHero supports all of your favorite chat platforms! Once installed you ca
 
 - [Webex Messaging](https://calendarhero.com/webex-meetings)
 
-- [SMS](https://calendarhero.com/sms)
+- SMS *(no longer available for new integrations; existing connections continue to work)*
 
 ### 
   


### PR DESCRIPTION
…new users

Adds a warning callout to the SMS setup article and removes the SMS sign-up link from the platforms list, reflecting that new SMS integrations are no longer available. Existing connections continue to work.