### PR TITLE
docs: fix empty markdown links breaking CalendarHero build

### DIFF
--- a/docusaurus/docs/calendarhero/scheduling-meetings/how-to-redirect-invitees-after-scheduling.md
+++ b/docusaurus/docs/calendarhero/scheduling-meetings/how-to-redirect-invitees-after-scheduling.md
@@ -19,7 +19,7 @@ Your Confirmation can be customized from any of your [Meeting Types](/calendarhe
 
   - We recommend 5 seconds so that the invitee can first read the important scheduling confirmation details that appear on the CalendarHero confirmation page. However, this can be set to 0 for an instant redirect.
 
-- Enter your custom URL - e.g. [www.mymarketingwebsite.com]()
+- Enter your custom URL - e.g. `www.mymarketingwebsite.com`
 
   - Note: For security reasons "https://" links are required
 

--- a/docusaurus/docs/calendarhero/scheduling-meetings/smart-meetings-command-overview.md
+++ b/docusaurus/docs/calendarhero/scheduling-meetings/smart-meetings-command-overview.md
@@ -5,7 +5,7 @@ sidebar_position: 29
 
 Using CalendarHero with your favourite chat platform? CalendarHero is built to understand a large number of requests and you can use plain English to communicate with the assistant. To get you started, try these commands below.  
 
-We also recommend this handy [Quick Start Guide (Blog)]() or jump right to How do I Schedule Meetings?
+We also recommend the Quick Start Guide (Blog) or jump right to How do I Schedule Meetings?
 
 What else can your assistant do? Check out this overview
 


### PR DESCRIPTION
Two files had `[]()` links with no URL, which Docusaurus rejects with "Markdown link URL is mandatory" during MDX compilation.

- scheduling-meetings/how-to-redirect-invitees-after-scheduling.md
- scheduling-meetings/smart-meetings-command-overview.md