### PR TITLE
Mirror yesware-docs content edits into yesware section

### DIFF
--- a/docusaurus/docs/yesware/campaigns/creating-campaigns.mdx
+++ b/docusaurus/docs/yesware/campaigns/creating-campaigns.mdx
@@ -1,5 +1,5 @@
 ---
-title: creating-campaigns
+title: Creating Campaigns
 sidebar_label: Create a Campaign
 description: Learn how to create and personalize multi-touch campaigns with automated and manual touches.
 tags:

--- a/docusaurus/docs/yesware/campaigns/index.mdx
+++ b/docusaurus/docs/yesware/campaigns/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: getting-started-with-campaigns
+title: Getting Started with Campaigns
 sidebar_label: Getting Started
 description: Learn how to use Campaigns to create multi-touch, multi-channel outreach sequences directly from your inbox.
 tags:
@@ -129,11 +129,11 @@ Once your campaign is created, you can add recipients using various methods:
 - Import from Salesforce (Enterprise plans only)
 - *(Gmail only)* Use the `Add to Campaigns` option from an email thread
 
-For detailed instructions on adding and managing recipients, see the [Managing Active Campaigns](managing-active-campaigns.mdx) article.
+For detailed instructions on adding and managing recipients, see the [Managing Active Campaigns](managing-active-campaigns) article.
 
 ### Step 4: Personalize your outreach
 
-Use merge fields, personalization columns, and the Preview & Personalize feature to customize messages for individual recipients. For detailed instructions, see the [Creating Campaigns](creating-campaigns.mdx) article.
+Use merge fields, personalization columns, and the Preview & Personalize feature to customize messages for individual recipients. For detailed instructions, see the [Creating Campaigns](creating-campaigns) article.
 
 ### Step 5: Launch and monitor
 

--- a/docusaurus/docs/yesware/campaigns/managing-active-campaigns.mdx
+++ b/docusaurus/docs/yesware/campaigns/managing-active-campaigns.mdx
@@ -1,5 +1,5 @@
 ---
-title: managing-active-campaigns
+title: Managing Active Campaigns
 sidebar_label: Manage Campaigns
 description: Learn how to add recipients, track performance, export data, and manage active campaigns.
 tags:
@@ -118,7 +118,7 @@ You can also add recipients one by one directly in the recipient table:
 
 In Gmail:
 
-1. Hover over the Yesware "Y" icon next to an email address in a thread.
+1. Hover over the Yesware icon next to an email address in a thread.
 2. Select `Add to Campaigns`.
 3. The Campaigns dashboard will open.
 4. Choose the Campaign you'd like to add the recipient to.

--- a/docusaurus/docs/yesware/campaigns/sharing-campaigns.mdx
+++ b/docusaurus/docs/yesware/campaigns/sharing-campaigns.mdx
@@ -1,5 +1,5 @@
 ---
-title: sharing-campaigns
+title: Sharing Campaigns
 sidebar_label: Share Campaigns
 description: Learn how to share campaigns with your team and track team-wide performance metrics.
 tags:

--- a/docusaurus/docs/yesware/contacts/creating-contacts.md
+++ b/docusaurus/docs/yesware/contacts/creating-contacts.md
@@ -1,5 +1,5 @@
 ---
-title: creating-and-editing-contacts
+title: Creating and Editing Contacts
 sidebar_label: Creating Contacts
 description: Learn how to create, edit, and delete contacts in Yesware for Gmail and Outlook.
 tags:

--- a/docusaurus/docs/yesware/contacts/index.md
+++ b/docusaurus/docs/yesware/contacts/index.md
@@ -1,5 +1,5 @@
 ---
-title: getting-started-with-contacts
+title: Getting Started with Contacts
 sidebar_label: Getting Started
 description: Learn how to access and use Contacts to manage your professional relationships and track interactions.
 tags:
@@ -66,7 +66,7 @@ Contacts does not integrate with Salesforce, but you can submit feedback via the
 
 If you're a Gmail user, you can also manage Contacts directly from your Yesware Sidebar:
 
-1. Click the **Y icon** to open the Yesware sidebar.
+1. Click the **Yesware icon** to open the Yesware sidebar.
 2. Click the **phone book icon** to access the Contacts tab.
 3. Use the **search bar** to find a profile by name or email.
 4. Click on a contact to view and edit their details.

--- a/docusaurus/docs/yesware/contacts/managing-contacts.md
+++ b/docusaurus/docs/yesware/contacts/managing-contacts.md
@@ -1,5 +1,5 @@
 ---
-title: managing-contacts
+title: Managing Contacts
 sidebar_label: Managing Contacts
 description: Learn how to manage contacts by adding notes, viewing timelines, enriching data, and exporting contact lists.
 tags:

--- a/docusaurus/docs/yesware/getting-started-with-yesware.mdx
+++ b/docusaurus/docs/yesware/getting-started-with-yesware.mdx
@@ -32,17 +32,17 @@ Yesware supports **Gmail** (via Chrome extension) and **Outlook (Office 365)** (
 **For Outlook (O365):**
 1. Visit [Microsoft AppSource](https://appsource.microsoft.com/en-us/product/office/WA104380259) and click **Get it Now**.
 2. Close and re-open Outlook.
-3. Open or compose an email. Click the blue **Y** on the right side of the ribbon to open the Yesware Sidebar.
+3. Open or compose an email. Click the blue **Yesware icon** on the right side of the ribbon to open the Yesware Sidebar.
 
 **For Outlook on Mac:**
 1. Compose a new email.
 2. Click **Apps** > **Get Add-ins**.
 3. Search for **Yesware** and click **Add**.
 
-See [Installing Yesware](./overview/installing-yesware/index.mdx) for more details. Enterprise users will also authenticate to Salesforce during setup.
+See [Installing Yesware](./overview/installing-yesware/) for more details. Enterprise users will also authenticate to Salesforce during setup.
 
 :::info
-Yesware for Outlook requires O365-hosted email. GoDaddy and other third-party hosted email may not work. See [troubleshooting](./overview/troubleshooting/index.mdx) if installation fails.
+Yesware for Outlook requires O365-hosted email. GoDaddy and other third-party hosted email may not work. See [troubleshooting](./overview/troubleshooting/) if installation fails.
 :::
 
 [Back to checklist](#getting-started-checklist)
@@ -56,9 +56,9 @@ After installation, sign in with your email to activate Yesware. The Sidebar is 
 ### How to open the Sidebar
 
 - **Gmail**: The Yesware panel appears when you compose or view emails. Use the Yesware icon in your inbox.
-- **Outlook**: Click the blue **Y** in the ribbon, or open **Get Add-ins** and select Yesware. Pin the Sidebar open in your compose window for easier access.
+- **Outlook**: Click the blue **Yesware icon** in the ribbon, or open **Get Add-ins** and select Yesware. Pin the Sidebar open in your compose window for easier access.
 
-If you do not see the Sidebar, see [Installing Yesware](./overview/installing-yesware/index.mdx) or [troubleshooting](./overview/troubleshooting/index.mdx).
+If you do not see the Sidebar, see [Installing Yesware](./overview/installing-yesware/) or [troubleshooting](./overview/troubleshooting/).
 
 [Back to checklist](#getting-started-checklist)
 
@@ -75,7 +75,7 @@ Yesware tracks when recipients open your emails and click links. Tracking is on 
 3. Send the email.
 4. View opens and clicks in your **Activity Feed**.
 
-See the [Activity & Email Tracking guide](./activity/index.mdx) for link tracking, attachment tracking, and privacy settings.
+See the [Activity & Email Tracking guide](./activity/) for link tracking, attachment tracking, and privacy settings.
 
 [Back to checklist](#getting-started-checklist)
 
@@ -97,7 +97,7 @@ Templates save reusable email copy. Campaigns let you run multi-touch sequences 
 2. Create a new campaign and add your email touches.
 3. Add recipients and launch. Yesware will manage follow-ups and tasks.
 
-See [Campaigns](./campaigns/index.mdx) and [Campaign Actions & Tasks](./campaigns/campaign-tasks.mdx) for details. You can also use [Meeting Scheduler](./meeting-scheduler/index.mdx) to share booking links.
+See [Campaigns](./campaigns/) and [Campaign Actions & Tasks](./campaigns/campaign-tasks) for details. You can also use [Meeting Scheduler](./meeting-scheduler/) to share booking links.
 
 [Back to checklist](#getting-started-checklist)
 
@@ -114,7 +114,7 @@ Enterprise plans can sync Yesware emails, opens, clicks, and activities to Sales
 3. Sign in to Salesforce and approve access.
 4. After connecting, use the regular send button (or **Send with Yesware** if required) so activities sync to the right Contact or Lead.
 
-See [Salesforce Integration](./settings/salesforce/index.mdx) for sync behavior, calendar sync, and the Salesforce sidebar. For best practices on deliverability, see [Email Deliverability](./overview/deliverability.mdx).
+See [Salesforce Integration](./settings/salesforce/) for sync behavior, calendar sync, and the Salesforce sidebar. For best practices on deliverability, see [Email Deliverability](./overview/deliverability).
 
 [Back to checklist](#getting-started-checklist)
 

--- a/docusaurus/docs/yesware/meeting-scheduler/index.mdx
+++ b/docusaurus/docs/yesware/meeting-scheduler/index.mdx
@@ -21,7 +21,7 @@ To set up Meeting Scheduler, open a new email message and click on the calendar 
 
 **My Calendar Link URL:** A custom URL that directs recipients to your booking page.
 
-**Web Conferencing:** If you use Zoom or Microsoft Teams, enable the integration to automatically insert a meeting link into booked meetings. See [Zoom Integration](./zoom-integration.mdx).
+**Web Conferencing:** If you use Zoom or Microsoft Teams, enable the integration to automatically insert a meeting link into booked meetings. See [Zoom Integration](./zoom-integration).
 
 ### Advanced Settings
 

--- a/docusaurus/docs/yesware/meeting-scheduler/team-meeting-types.mdx
+++ b/docusaurus/docs/yesware/meeting-scheduler/team-meeting-types.mdx
@@ -21,7 +21,7 @@ Once saved, the meeting type is available to all team members and their recipien
 
 :::note
 - Meetings book on each team member's default calendar
-- The location field is blank unless the team member has set up the [Zoom integration](./zoom-integration.mdx)
+- The location field is blank unless the team member has set up the [Zoom integration](./zoom-integration)
 - Team Meeting Types can only be edited by Team Leaders of that specific team
 - A Team Meeting Type belongs to one team only and cannot be shared across multiple teams
 :::

--- a/docusaurus/docs/yesware/overview/advanced-features.mdx
+++ b/docusaurus/docs/yesware/overview/advanced-features.mdx
@@ -63,7 +63,7 @@ Use the "Preview & Personalize" button to see how each email will read for your 
 
 **5. Once you are all set, finalize the mail merge by clicking "Start Campaign."**
 
-For more detailed instructions, please view [this article.](../campaigns/index.mdx)
+For more detailed instructions, please view [this article.](../campaigns/)
 
 ### Mail Merge Best Practices
 
@@ -133,7 +133,7 @@ Sending a mail merge in Outlook is easy with Yesware Campaigns feature. To start
 5. Preview your emails using the "Preview & Personalize" button.
 6. Click "Start Campaign" to send.
 
-For more detailed instructions, please view [this article.](../campaigns/index.mdx)
+For more detailed instructions, please view [this article.](../campaigns/)
 
 ### Can I use templates with mail merge?
 

--- a/docusaurus/docs/yesware/overview/index.mdx
+++ b/docusaurus/docs/yesware/overview/index.mdx
@@ -6,7 +6,7 @@ sidebar_position: 0
 
 # Yesware Overview
 
-The Overview section covers Yesware setup, core features, and troubleshooting. New to Yesware? Start with [Getting Started with Yesware](../getting-started-with-yesware.mdx) to install and configure your account.
+The Overview section covers Yesware setup, core features, and troubleshooting. New to Yesware? Start with [Getting Started with Yesware](../getting-started-with-yesware) to install and configure your account.
 
 ## What is Yesware?
 
@@ -20,19 +20,19 @@ Yesware is a sales engagement platform that integrates with your Gmail or Outloo
 
 ## Platform compatibility
 
-Yesware supports **Gmail** (via Chrome extension) and **Outlook (Office 365)** (via O365 add-in). See [How do I install Yesware?](./installing-yesware/index.mdx) for installation steps.
+Yesware supports **Gmail** (via Chrome extension) and **Outlook (Office 365)** (via O365 add-in). See [How do I install Yesware?](./installing-yesware/) for installation steps.
 
 ## What's included
 
-- **[Email Tracking](../activity/index.mdx)**: Track opens, clicks, and engagement on your emails
-- **[Multi-Channel Campaigns](../campaigns/index.mdx)**: Automate multi-touch outreach sequences
-- **[Campaign Actions & Tasks](../campaigns/campaign-tasks.mdx)**: Manage your campaign to-dos
-- **[Meeting Scheduler](../meeting-scheduler/index.mdx)**: Eliminate back-and-forth when scheduling meetings
+- **[Email Tracking](../activity/)**: Track opens, clicks, and engagement on your emails
+- **[Multi-Channel Campaigns](../campaigns/)**: Automate multi-touch outreach sequences
+- **[Campaign Actions & Tasks](../campaigns/campaign-tasks)**: Manage your campaign to-dos
+- **[Meeting Scheduler](../meeting-scheduler/)**: Eliminate back-and-forth when scheduling meetings
 - **Account Management**: Manage your subscription and team
-- **[Salesforce Integration](../settings/salesforce/index.mdx)**: Connect your CRM (Enterprise plans)
-- **[Email Deliverability](deliverability.mdx)**: Best practices for avoiding spam filters
-- **[Advanced Features](advanced-features.mdx)**: Learn about additional capabilities
-- **[Troubleshooting](./troubleshooting/index.mdx)**: Common issues and solutions
+- **[Salesforce Integration](../settings/salesforce/)**: Connect your CRM (Enterprise plans)
+- **[Email Deliverability](deliverability)**: Best practices for avoiding spam filters
+- **[Advanced Features](advanced-features)**: Learn about additional capabilities
+- **[Troubleshooting](./troubleshooting/)**: Common issues and solutions
 
 ## Frequently asked questions
 

--- a/docusaurus/docs/yesware/overview/installing-yesware/index.mdx
+++ b/docusaurus/docs/yesware/overview/installing-yesware/index.mdx
@@ -35,7 +35,7 @@ Already have an account? Use the [direct Gmail install link](https://app.yesware
 ### Outlook (O365)
 1. Visit [Microsoft AppSource](https://appsource.microsoft.com/en-us/product/office/WA104380259) and click **Get it Now**.
 2. Close and re-open Outlook.
-3. Open or compose an email. Click the blue **Y** that appears in the Outlook ribbon to open the Yesware Sidebar.
+3. Open or compose an email. Click the blue **Yesware icon** that appears in the Outlook ribbon to open the Yesware Sidebar.
 4. Sign in with your email address to connect your account.
 
 If you're on the Enterprise plan, you'll also be prompted to authenticate with Salesforce.
@@ -45,7 +45,7 @@ If you're on the Enterprise plan, you'll also be prompted to authenticate with S
 The Sidebar is where you access tracking, templates, campaigns, and Meeting Scheduler. In Outlook, there are two Sidebars — one for your inbox and one for composing — and both need to be opened and pinned.
 
 ### Outlook Desktop
-Click the blue **Y** in the ribbon when viewing or composing an email.
+Click the blue **Yesware icon** in the ribbon when viewing or composing an email.
 
 ### Outlook Web App
 1. Open any email and click the ellipsis (**...**) in the upper right corner of the message.

--- a/docusaurus/docs/yesware/overview/reminders/how-do-i-use-yesware-reminders-in.mdx
+++ b/docusaurus/docs/yesware/overview/reminders/how-do-i-use-yesware-reminders-in.mdx
@@ -18,4 +18,4 @@ You can always go to the sent message and click the "Remind" button in the upper
 ### Can I set a Reminder on an incoming email?
 Yes!  Similar to setting a Reminder retroactively, open the incoming email.  You should see the Remind button in the upper right.
 ### How do I view Upcoming Reminders?
-In the Activity Feed, click "Scheduled."  Here you will see any upcoming Reminders as well as any upcoming[Send Laters](../send-later/put-your-outreach-on-autopilot-with-send.mdx)you may have.
+In the Activity Feed, click "Scheduled."  Here you will see any upcoming Reminders as well as any upcoming[Send Laters](../send-later/put-your-outreach-on-autopilot-with-send)you may have.

--- a/docusaurus/docs/yesware/overview/reminders/prioritize-email-follow-ups-with-yesware-reminders.mdx
+++ b/docusaurus/docs/yesware/overview/reminders/prioritize-email-follow-ups-with-yesware-reminders.mdx
@@ -25,4 +25,4 @@ You can always go to the sent message and click the "Remind" button in the upper
 ### Can I set a Reminder on an incoming email?
 Yes!  Similar to setting a Reminder retroactively, open the incoming email.  You should see the Remind button in the upper right.
 ### How do I view upcoming Reminders?
-In the Activity Feed, click "Scheduled."  Here you will see any upcoming Reminders (as well as any upcoming [Send Laters](../send-later/put-your-outreach-on-autopilot-with-send.mdx)) you may have.
+In the Activity Feed, click "Scheduled."  Here you will see any upcoming Reminders (as well as any upcoming [Send Laters](../send-later/put-your-outreach-on-autopilot-with-send)) you may have.

--- a/docusaurus/docs/yesware/reporting/index.md
+++ b/docusaurus/docs/yesware/reporting/index.md
@@ -20,13 +20,13 @@ Yesware's reporting suite gives you clear insight into how your outreach is perf
 
 | Report | What it shows |
 |---|---|
-| [My Dashboard](./what-is-my-dashboard-in-reporting.mdx) | Personal activity snapshot for the last 7 days |
-| [Email Activity Report](./what-data-is-shown-in-the-email.mdx) | Sends, open rates, and reply rates for you and your team |
-| [Templates Report](./what-data-is-shown-on-the-templates.mdx) | Template usage and performance by user and by template |
-| [Campaigns Report](./what-data-is-shown-on-the-campaigns.mdx) | Campaign open, click, and connection rates |
-| [Recipient Engagement Report](./what-data-is-shown-on-the-recipient.mdx) | Engagement history for individual recipients |
-| [Link Click Engagement Report](./what-data-is-shown-on-the-link.mdx) | Which tracked links recipients are clicking |
-| [Salesforce Reporting](./salesforce-reporting.mdx) | Yesware activity reports inside Salesforce (Enterprise only) |
+| [My Dashboard](./what-is-my-dashboard-in-reporting) | Personal activity snapshot for the last 7 days |
+| [Email Activity Report](./what-data-is-shown-in-the-email) | Sends, open rates, and reply rates for you and your team |
+| [Templates Report](./what-data-is-shown-on-the-templates) | Template usage and performance by user and by template |
+| [Campaigns Report](./what-data-is-shown-on-the-campaigns) | Campaign open, click, and connection rates |
+| [Recipient Engagement Report](./what-data-is-shown-on-the-recipient) | Engagement history for individual recipients |
+| [Link Click Engagement Report](./what-data-is-shown-on-the-link) | Which tracked links recipients are clicking |
+| [Salesforce Reporting](./salesforce-reporting) | Yesware activity reports inside Salesforce (Enterprise only) |
 
 ## Frequently asked questions
 

--- a/docusaurus/docs/yesware/reporting/what-data-is-shown-on-the-templates.mdx
+++ b/docusaurus/docs/yesware/reporting/what-data-is-shown-on-the-templates.mdx
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 # Templates Report
 
-The [Templates Report](https://app.yesware.com/reports/templates/#/templates/by_template) shows the usage and performance of your templates, so sales leaders can see which templates are performing well and team members can follow what's working. You can [filter and sort](how-do-i-filter-in-the-email.mdx) the data by reporting period for more targeted analysis.
+The [Templates Report](https://app.yesware.com/reports/templates/#/templates/by_template) shows the usage and performance of your templates, so sales leaders can see which templates are performing well and team members can follow what's working. You can [filter and sort](how-do-i-filter-in-the-email) the data by reporting period for more targeted analysis.
 
 ## Templates by Template
 

--- a/docusaurus/docs/yesware/settings/index.mdx
+++ b/docusaurus/docs/yesware/settings/index.mdx
@@ -7,8 +7,8 @@ description: "Manage your Yesware account settings, plans, billing, users, notif
 
 Manage your Yesware account, team, billing, and integrations from one place.
 
-- **[Plans & Pricing](./plans-pricing/index.mdx)** — Upgrade, cancel, and update your payment method
-- **[BCC to CRM](./bcc-to-crm/index.mdx)** — Automatically log emails to your CRM via BCC
+- **[Plans & Pricing](./plans-pricing/)** — Upgrade, cancel, and update your payment method
+- **[BCC to CRM](./bcc-to-crm/)** — Automatically log emails to your CRM via BCC
 
 ---
 

--- a/docusaurus/docs/yesware/settings/plans-pricing/index.mdx
+++ b/docusaurus/docs/yesware/settings/plans-pricing/index.mdx
@@ -36,7 +36,7 @@ Yesware accepts payment by credit card. PayPal is not accepted.
 <details>
 <summary>What happens to my data if I cancel?</summary>
 
-Your account moves to the Free Plan at the end of your billing period. Your templates, campaigns, teams, and tracking history are preserved. See the Free Plan section in [Installing Yesware](../../overview/installing-yesware/index.mdx) for what's included.
+Your account moves to the Free Plan at the end of your billing period. Your templates, campaigns, teams, and tracking history are preserved. See the Free Plan section in [Installing Yesware](../../overview/installing-yesware/) for what's included.
 
 </details>
 

--- a/docusaurus/docs/yesware/settings/salesforce/calendar-sync/how-do-i-use-the-salesforce-calendar.mdx
+++ b/docusaurus/docs/yesware/settings/salesforce/calendar-sync/how-do-i-use-the-salesforce-calendar.mdx
@@ -10,7 +10,7 @@ sidebar_position: 3
 To use Yesware's Calendar Sync in O365:
 - Open up a new meeting and click "Invite Attendees."
 - Invite whomever needs to attend the meeting. 
-- Select the Yesware Y in the Outlook ribbon - this will open up Yesware's sidebar within the meeting invite.
+- Select the Yesware icon in the Outlook ribbon - this will open up Yesware's sidebar within the meeting invite.
 - As long as the "Salesforce Sync" is toggled on, it will include a unique Salesforce sync address in your list of attendees.
 - Send the invite.
 When you then send the invitation, this meeting will sync as an open activity to the **first recipient on the invitation with a Contact or Lead record**. It will sync it to Salesforce as an Event in the Open Events until the date and time have come and gone, and it will then appear in the Activity History.

--- a/docusaurus/docs/yesware/settings/salesforce/calendar-sync/index.mdx
+++ b/docusaurus/docs/yesware/settings/salesforce/calendar-sync/index.mdx
@@ -26,19 +26,19 @@ You can sync events up to 30 days in the past and any future events. If [Shared 
 
 To sync an **inbound event**, open the event, confirm Calendar Sync is toggled on, verify the associated records, and click **Save**. Any edits to already-synced events update in Salesforce automatically.
 
-For a full walkthrough including two-way sync, see [Calendar Sync in Gmail](how-do-i-use-yesware-calendar-sync.mdx).
+For a full walkthrough including two-way sync, see [Calendar Sync in Gmail](how-do-i-use-yesware-calendar-sync).
 
 ## Sync an Outlook (O365) event
 
 1. Open a new meeting in Outlook and click **Invite Attendees**.
 2. Add your attendees.
-3. Click the **Yesware Y** in the Outlook ribbon to open the Yesware Sidebar within the invite.
+3. Click the **Yesware icon** in the Outlook ribbon to open the Yesware Sidebar within the invite.
 4. With Salesforce Sync toggled on, a unique sync address is automatically added to the attendees list.
 5. Send the invite.
 
 The meeting syncs as an open activity to the first recipient who has a matching Contact or Lead in Salesforce. Note that retroactive syncing and syncing of inbound invites are not supported in O365.
 
-For full details, see [Calendar Sync in Outlook](how-do-i-use-the-salesforce-calendar.mdx).
+For full details, see [Calendar Sync in Outlook](how-do-i-use-the-salesforce-calendar).
 
 ## Where synced events appear
 

--- a/docusaurus/docs/yesware/settings/salesforce/getting-started/index.mdx
+++ b/docusaurus/docs/yesware/settings/salesforce/getting-started/index.mdx
@@ -44,7 +44,7 @@ You can use these custom Yesware fields to build reports in Salesforce:
 | **Yesware Template Name** | Which template was used — useful for comparing messaging effectiveness |
 | **Yesware Is Campaign** | True/False — whether the task was created as part of a Yesware Campaign |
 
-For a full walkthrough on building reports and dashboards using these fields, see [Team Reporting](measure-your-team-s-yesware-effectiveness-with.mdx) and [Dashboards](using-yesware-data-to-build-salesforce-dashboards.mdx).
+For a full walkthrough on building reports and dashboards using these fields, see [Team Reporting](measure-your-team-s-yesware-effectiveness-with) and [Dashboards](using-yesware-data-to-build-salesforce-dashboards).
 
 ## Salesforce AppExchange
 

--- a/docusaurus/docs/yesware/settings/salesforce/sync/index.mdx
+++ b/docusaurus/docs/yesware/settings/salesforce/sync/index.mdx
@@ -51,13 +51,13 @@ To associate email activity with an Opportunity, assign the recipient Contact as
 
 By default, Yesware creates separate tasks for each activity type. If you'd prefer a single consolidated task per email — with counts and timestamps for each event type — you can enable **Summary Task Logging**. This requires installing a Salesforce package and contacting Yesware support to activate it.
 
-See [Summary Task Logging](how-do-i-leverage-summary-task-logging.mdx) for setup steps.
+See [Summary Task Logging](how-do-i-leverage-summary-task-logging) for setup steps.
 
 ## Dynamic Templates
 
 Enterprise users can personalise templates using live data from Salesforce Contact or Lead records. When you select a template, Yesware looks up the first recipient in the To field and auto-fills any dynamic fields with matching Salesforce data.
 
-See [Dynamic Templates](how-do-dynamic-templates-work-with-salesforce.mdx) for setup and field reference.
+See [Dynamic Templates](how-do-dynamic-templates-work-with-salesforce) for setup and field reference.
 
 ## Common questions
 
@@ -106,6 +106,6 @@ Yesware uses API calls for Sidebar lookups and email sync actions — some activ
 <details>
 <summary>Why isn't Send to Salesforce working?</summary>
 
-Check that Send to Salesforce is toggled on in your Yesware preferences. If it is on but emails still aren't syncing, deauthorize and reauthorize your Salesforce connection from the Yesware web app. If the issue continues, ask your Salesforce administrator to confirm your user profile has API access enabled. Note that Yesware does not sync emails sent to addresses on the same domain as your own, or to addresses with no matching Contact or Lead. See [Troubleshooting](why-isn-t-send-to-salesforce-working.mdx) for more detail.
+Check that Send to Salesforce is toggled on in your Yesware preferences. If it is on but emails still aren't syncing, deauthorize and reauthorize your Salesforce connection from the Yesware web app. If the issue continues, ask your Salesforce administrator to confirm your user profile has API access enabled. Note that Yesware does not sync emails sent to addresses on the same domain as your own, or to addresses with no matching Contact or Lead. See [Troubleshooting](why-isn-t-send-to-salesforce-working) for more detail.
 
 </details>

--- a/docusaurus/docs/yesware/templates/creating-templates/creating-yesware-templates-in-gmail.mdx
+++ b/docusaurus/docs/yesware/templates/creating-templates/creating-yesware-templates-in-gmail.mdx
@@ -44,4 +44,4 @@ Use merge fields to personalize templates for each recipient. See [Merge Fields]
 
 ## Team template sharing
 
-On Premium and Enterprise plans, you can share templates with your team. See [Share Templates](../sharing-templates/how-do-i-share-templates) for details.
+On Premium and Enterprise plans, you can share templates with your team. After you create the template, click **Share with team**.

--- a/docusaurus/docs/yesware/templates/creating-templates/creating-yesware-templates-in-outlook.mdx
+++ b/docusaurus/docs/yesware/templates/creating-templates/creating-yesware-templates-in-outlook.mdx
@@ -24,7 +24,7 @@ Use merge fields to personalize templates for each recipient. In the template ed
 
 **Dropdown Field** — A pick-list with up to 5 options you define when creating the template.
 
-**Salesforce Field** *(Enterprise only)* — Pulls data automatically from the matching Contact or Lead record in Salesforce (e.g., name, company, job title). See [How do dynamic templates work with Salesforce?](../../settings/salesforce/sync/how-do-dynamic-templates-work-with-salesforce.mdx) for details.
+**Salesforce Field** *(Enterprise only)* — Pulls data automatically from the matching Contact or Lead record in Salesforce (e.g., name, company, job title). See [How do dynamic templates work with Salesforce?](../../settings/salesforce/sync/how-do-dynamic-templates-work-with-salesforce) for details.
 
 When you add hyperlinks to a template, they are automatically set up as tracked links.
 

--- a/docusaurus/docs/yesware/templates/creating-templates/index.mdx
+++ b/docusaurus/docs/yesware/templates/creating-templates/index.mdx
@@ -25,7 +25,7 @@ You can create a template four ways:
 2. Click **Save as Template** at the top of the email.
 3. Remove any recipient-specific content, then save.
 
-See [Create in Gmail](creating-yesware-templates-in-gmail.mdx) for the full walkthrough.
+See [Create in Gmail](creating-yesware-templates-in-gmail) for the full walkthrough.
 
 ## Create a template in Outlook
 
@@ -34,7 +34,7 @@ See [Create in Gmail](creating-yesware-templates-in-gmail.mdx) for the full walk
 3. Write your message and set the name, subject, and style options.
 4. Click **Save Template**.
 
-See [Create in Outlook](creating-yesware-templates-in-outlook.mdx) for the full walkthrough including how to insert and use templates.
+See [Create in Outlook](creating-yesware-templates-in-outlook) for the full walkthrough including how to insert and use templates.
 
 ## Merge fields
 
@@ -46,7 +46,7 @@ Merge fields let you personalize templates for each recipient. Yesware supports 
 | **Dropdown Field** | A pick-list with up to 5 options you define |
 | **Salesforce Field** *(Enterprise only)* | Auto-fills from the matching Contact or Lead record |
 
-See [Merge Fields](how-to-use-placeholders-merge-fields-in.mdx) for step-by-step setup.
+See [Merge Fields](how-to-use-placeholders-merge-fields-in) for step-by-step setup.
 
 ## Common questions
 

--- a/docusaurus/docs/yesware/templates/index.md
+++ b/docusaurus/docs/yesware/templates/index.md
@@ -54,7 +54,7 @@ Not directly. Take a screenshot of the video, insert it as an image in the templ
 <details>
 <summary>Can I use dynamic Salesforce fields in templates?</summary>
 
-Yes, on the Enterprise plan. When you select a template, Yesware looks up the first recipient in the To field and auto-fills any Salesforce merge fields with matching Contact or Lead data. See [Dynamic Templates](../settings/salesforce/sync/how-do-dynamic-templates-work-with-salesforce.mdx) for details.
+Yes, on the Enterprise plan. When you select a template, Yesware looks up the first recipient in the To field and auto-fills any Salesforce merge fields with matching Contact or Lead data. See [Dynamic Templates](../settings/salesforce/sync/how-do-dynamic-templates-work-with-salesforce) for details.
 
 </details>
 

--- a/docusaurus/docs/yesware/templates/using-templates/index.mdx
+++ b/docusaurus/docs/yesware/templates/using-templates/index.mdx
@@ -14,7 +14,7 @@ Once you've created a template, you can insert it into any email in Gmail or Out
    - **Fill In** — opens the template to complete any merge fields before inserting.
    - **Insert** — inserts as-is. Use this only for templates without merge fields.
 
-See [Use in Gmail](using-yesware-templates-in-gmail.mdx) for the full walkthrough including template reporting.
+See [Use in Gmail](using-yesware-templates-in-gmail) for the full walkthrough including template reporting.
 
 ## Favorite templates
 
@@ -47,14 +47,14 @@ Click the **chain link icon** in the template editor, enter the URL, and click *
 <details>
 <summary>How do I add attachments to a template?</summary>
 
-Click **Insert Attachment** in the template editor and select the file. For PDF and PPT files, you also get two options: **Allow recipient to download** (recipients can save a copy, but you lose visibility after download) and **Ask the recipient to enter their name to access** (gates the file behind a name field, and your Presentation Report shows who viewed it and for how long). See [Attachments](how-do-i-add-attachments-to-templates.mdx) for full details.
+Click **Insert Attachment** in the template editor and select the file. For PDF and PPT files, you also get two options: **Allow recipient to download** (recipients can save a copy, but you lose visibility after download) and **Ask the recipient to enter their name to access** (gates the file behind a name field, and your Presentation Report shows who viewed it and for how long). See [Attachments](how-do-i-add-attachments-to-templates) for full details.
 
 </details>
 
 <details>
 <summary>Can I use dynamic merge fields in a template?</summary>
 
-Yes. Templates support Text Fields (free-form), Dropdown Fields (pick-list), and Salesforce Fields (Enterprise only, auto-fills from Contact or Lead). See [Merge Fields](../creating-templates/how-to-use-placeholders-merge-fields-in.mdx) for setup instructions.
+Yes. Templates support Text Fields (free-form), Dropdown Fields (pick-list), and Salesforce Fields (Enterprise only, auto-fills from Contact or Lead). See [Merge Fields](../creating-templates/how-to-use-placeholders-merge-fields-in) for setup instructions.
 
 </details>
 


### PR DESCRIPTION
Ports two yesware-docs commits (130eeb0, 96e691c) across 28 files:
- Rename old "Yesware Y" logo references to "Yesware icon" (6 files)
- Title-case 7 frontmatter titles that used hyphen-delimited ids
- Strip .mdx/.md and trailing /index from internal links (~32 links)
- Replace the broken ../sharing-templates/how-do-i-share-templates reference with an inline "Share with team" instruction