### PR TITLE
Mirror tool: Creates a PR on the yesware-docs repo upon every Yesware-related merge in BusinessApp

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [master]
     paths:
-      - "docusaurus/docs/**"
+      - "docusaurus/docs/yesware/**"
+  schedule:
+    - cron: "0 16 * * *"   # Daily at 11am CT (4pm UTC)
   workflow_dispatch:
     inputs:
       sync_name:


### PR DESCRIPTION
## Summary

- Narrowed the push trigger from `docusaurus/docs/**` to `docusaurus/docs/yesware/**` so the sync workflow only runs when yesware documentation is changed — not on every docs edit across the repo.
- Added a daily cron schedule (11am CT / 4pm UTC) as a safety net to catch any changes that may not have triggered the push event.

## How the sync works

When a PR is merged to master that touches `docusaurus/docs/yesware/`, this workflow mirrors those files to `vendasta/yesware-docs` under `docusaurus/docs/` and opens a PR there. The sync is one-way — businessapp-docs is the source of truth. Files deleted from the source are also deleted in the target (full mirror).

## No functional changes

The sync script (`scripts/sync-docs.sh`) and config (`docs-sync.yml`) are unchanged. This PR only adjusts when the workflow triggers.