### PR TITLE
fix: strip yesware/ prefix from category IDs during docs sync

### DIFF
--- a/scripts/sync-docs.sh
+++ b/scripts/sync-docs.sh
@@ -110,6 +110,13 @@ for ((i = 0; i < SYNC_COUNT; i++)); do
   rm -rf "$TARGET_DIR/${TARGET_PATH:?}/"*
   cp -r "$SOURCE_FULL/"* "$TARGET_DIR/$TARGET_PATH/"
 
+  # Fix Docusaurus IDs: strip the source folder prefix (e.g. "yesware/")
+  # In businessapp-docs, IDs include the parent folder (e.g. "yesware/activity/index")
+  # but in the target repo the files live at the root of docs, so the prefix must go.
+  SOURCE_PREFIX="$(basename "$SOURCE_PATH")"
+  find "$TARGET_DIR/$TARGET_PATH" -name "_category_.json" -exec \
+    sed -i "s|\"id\": \"${SOURCE_PREFIX}/|\"id\": \"|g" {} +
+
   # Configure git identity for the commit
   cd "$TARGET_DIR"
   git config user.name "docs-sync[bot]"


### PR DESCRIPTION
## Summary

- After copying files from businessapp-docs to yesware-docs, the sync script now strips the `yesware/` prefix from `"id"` fields in `_category_.json` files. In businessapp-docs the IDs are relative to the `docs/` root (e.g. `yesware/activity/index`), but in yesware-docs there's no `yesware/` parent folder, so the IDs need to be `activity/index`.
- Without this fix, Docusaurus sidebar links in yesware-docs point to non-existent paths.