### PR TITLE
Remove the test paragraph from a yesware campaign article

### DIFF
--- a/docusaurus/docs/yesware/campaigns/creating-campaigns.mdx
+++ b/docusaurus/docs/yesware/campaigns/creating-campaigns.mdx
@@ -17,8 +17,6 @@ keywords:
 
 # Creating Campaigns
 
-Test: This paragraph was added as a test change to verify the editing workflow.
-
 ## What is campaign creation?
 
 Campaign creation is the process of building multi-touch, multi-channel outreach sequences that can include automated emails, manual emails, phone calls, LinkedIn tasks, and other touch types. When you create a campaign, you define the content, timing, and structure of your outreach sequence.


### PR DESCRIPTION
This paragraph had been created to test the mirror tool. Removing it now.