### PR TITLE
docs: update Vibe intro and structure

### DIFF
--- a/docusaurus/docs/business-app/ai/knowledge-base.md
+++ b/docusaurus/docs/business-app/ai/knowledge-base.md
@@ -1,7 +1,7 @@
 ---
 title: Knowledge Base Overview
 sidebar_label: Knowledge Base
-sidebar_position: 3
+sidebar_position: 4
 description: Centralize information for AI Employees to reference when answering customer questions.
 tags: [ai-employees, knowledge-base, setup]
 keywords: [AI Knowledge Base, AI data sources, business info for AI, AI training data, document upload]

--- a/docusaurus/docs/business-app/ai/vibe/_category_.json
+++ b/docusaurus/docs/business-app/ai/vibe/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Vibe",
+  "position": 3,
+  "collapsed": true,
+  "link": {
+    "type": "doc",
+    "id": "business-app/ai/vibe/index"
+  }
+}

--- a/docusaurus/docs/business-app/ai/vibe/getting-started.md
+++ b/docusaurus/docs/business-app/ai/vibe/getting-started.md
@@ -139,13 +139,3 @@ The top-right toolbar provides:
 - **Paste a URL** — If a website you like is closer to your target than words can describe, paste its URL and Vibe will clone the look and structure as a starting point.
 - **Read the COMPLETED block** — The collapsible "Architecture & Navigation" and "Files" details show what shipped. After a big change, expanding them is the fastest way to confirm Vibe interpreted your prompt the way you meant it.
 
-## Next Steps
-
-- [Prompting Guide](./guides/prompting.md) — The principles behind effective prompts.
-- [Prompting library](./guides/prompting-library.md) — Concrete prompts you can paste, organized by intent.
-- [Cloning a reference site](./guides/clone-from-url.md) — Start from an existing site by pasting its URL.
-- [Visual Editor & Themes](./guides/visual-editor.md) — Customize colors and styles, and click elements in design mode to edit them precisely.
-- [Planning](./guides/plan-mode.md) — How Vibe sequences your generation: plan, build, validate, fix, complete.
-- [Connectors](./guides/connectors/index.md) — Wire your app into Forms, Single sign-on, and Analytics.
-- [Image generation](./guides/image-generation.md) — Produce hosted images on demand from your prompts.
-- [Error handling and troubleshooting](./guides/troubleshooting.md) — How auto-fix works and what to do when it doesn't.

--- a/docusaurus/docs/business-app/ai/vibe/getting-started.md
+++ b/docusaurus/docs/business-app/ai/vibe/getting-started.md
@@ -19,26 +19,17 @@ Vibe lives in Business App alongside your other AI tools.
 
 You see your Vibe project list. If this is your first time, the list is empty and invites you to create your first app.
 
-<figure>
-  <img src="./img/vibe-nav-entry.png" alt="Business App left navigation with the AI section expanded and Vibe highlighted, showing the empty Vibe project list" />
-  <figcaption>Vibe lives under AI in the Business App left navigation, alongside Workforce, Capabilities, and Knowledge base.</figcaption>
-</figure>
+![Business App left navigation with the AI section expanded and Vibe highlighted, showing the empty Vibe project list](./img/vibe-nav-entry.png)
 
 ## Step 2: Create a New Project
 
 Once you're in Vibe, you'll see a project list. Click **+ Create a new app** to create your first application.
 
-<figure>
-  <img src="./img/project-list.png" alt="Empty Vibe project list with the Create a new app button" />
-  <figcaption>An empty Vibe project list — the starting point for your first app.</figcaption>
-</figure>
+![Empty Vibe project list with the Create a new app button](./img/project-list.png)
 
 Give your project a name and an optional description, then click **Create**.
 
-<figure>
-  <img src="./img/create-project.png" alt="Create a new app dialog with the App Name and Description fields filled in" />
-  <figcaption>The create project dialog asks for a name and an optional description.</figcaption>
-</figure>
+![Create a new app dialog with the App Name and Description fields filled in](./img/create-project.png)
 
 ## Step 3: Write Your First Prompt
 
@@ -50,10 +41,7 @@ The editor has three main areas:
 - **Preview** (center) — A live preview of your application
 - **Mode Tabs** (top) — Switch between Preview, Design, and Code views
 
-<figure>
-  <img src="./img/empty-project.png" alt="Newly created Vibe project — empty chat panel on the left, welcome state with example prompts on the right" />
-  <figcaption>A new project: the chat panel waits for your first prompt while the preview area shows starter examples.</figcaption>
-</figure>
+![Newly created Vibe project — empty chat panel on the left, welcome state with example prompts on the right](./img/empty-project.png)
 
 Type your first prompt in the chat input at the bottom of the chat panel. Here are some good starting prompts:
 
@@ -82,10 +70,7 @@ After you submit your prompt, Vibe runs through a consistent sequence you can fo
 6. **Checking for errors** — If anything is broken, Vibe fixes it before declaring the run finished. See [Error handling and troubleshooting](./guides/troubleshooting.md) for how the auto-fix layers work.
 7. **Completed** — A `COMPLETED` block appears at the bottom of the conversation with collapsible "Architecture & Navigation" and "Files" details.
 
-<figure>
-  <img src="./img/generation-in-progress.png" alt="Vibe actively editing files during generation" />
-  <figcaption>Vibe streams its work into the chat as it runs — a status row per file edit, image generation step, and validation check.</figcaption>
-</figure>
+![Vibe actively editing files during generation](./img/generation-in-progress.png)
 
 The chat auto-scrolls to follow new events as they arrive. If you scroll up to read older context, follow-tail pauses; scroll back near the bottom and it resumes.
 
@@ -118,16 +103,13 @@ At the bottom of the chat panel, you find:
 
 | Control | Description |
 |---------|-------------|
-| **Text input** | Type your prompt here. Press Enter to send, Shift+Enter for a new line. Paste a URL in the input to clone a reference site (see [Cloning a reference site](./clone-from-url.md)). |
+| **Text input** | Type your prompt here. Press Enter to send, Shift+Enter for a new line. Paste a URL in the input to clone a reference site (see [Cloning a reference site](./guides/clone-from-url.md)). |
 | **+ (image)** | Attach screenshots or mockups to show Vibe what you want. |
 | **Mode selector** | Pick the generation mode for the next prompt. |
 | **Microphone** | Record voice input. Vibe transcribes your speech into a prompt. |
 | **Send** | Submit the prompt to Vibe. |
 
-<figure>
-  <img src="./img/chat-input.png" alt="The Vibe chat input with a sample prompt typed in, showing the image, mode, microphone, and send controls" />
-  <figcaption>The chat input combines free-text, an image attach control, a mode selector, voice input, and a send button.</figcaption>
-</figure>
+![The Vibe chat input with a sample prompt typed in, showing the image, mode, microphone, and send controls](./img/chat-input.png)
 
 ### Preview, Design, and Code Modes
 
@@ -137,10 +119,7 @@ Use the tabs at the top to switch between views:
 - **Design** — Visual editor for themes, colors, and element-level edits. See [Visual Editor](./guides/visual-editor.md).
 - **Code** — File explorer and code editor to view or manually edit source files
 
-<figure>
-  <img src="./img/code-view.png" alt="Code mode with the file tree open and App.tsx loaded in the editor" />
-  <figcaption>Code mode pairs a file tree with a syntax-highlighted editor for direct source edits.</figcaption>
-</figure>
+![Code mode with the file tree open and App.tsx loaded in the editor](./img/code-view.png)
 
 ### Toolbar
 
@@ -164,7 +143,7 @@ The top-right toolbar provides:
 
 - [Prompting Guide](./guides/prompting.md) — The principles behind effective prompts.
 - [Prompting library](./guides/prompting-library.md) — Concrete prompts you can paste, organized by intent.
-- [Cloning a reference site](./clone-from-url.md) — Start from an existing site by pasting its URL.
+- [Cloning a reference site](./guides/clone-from-url.md) — Start from an existing site by pasting its URL.
 - [Visual Editor & Themes](./guides/visual-editor.md) — Customize colors and styles, and click elements in design mode to edit them precisely.
 - [Planning](./guides/plan-mode.md) — How Vibe sequences your generation: plan, build, validate, fix, complete.
 - [Connectors](./guides/connectors/index.md) — Wire your app into Forms, Single sign-on, and Analytics.

--- a/docusaurus/docs/business-app/ai/vibe/guides/_category_.json
+++ b/docusaurus/docs/business-app/ai/vibe/guides/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Guides",
+  "collapsed": true
+}

--- a/docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md
@@ -63,10 +63,10 @@ Vibe replaces sections rather than rebuilding everything. Useful when only part 
 
 - **Use a clean reference.** A page with a clear, focused layout produces a better clone than a busy page with many unrelated sections.
 - **Single-page references work best.** Most clones target one page. If you want a multi-page site, scaffold the first page from a URL, then use follow-up prompts to add additional pages.
-- **Iterate after the first clone.** The first generation gets you 70% of the way. Use the prompting library's [refining recipes](./guides/prompting-library.md#refining-an-existing-app) to push it the rest of the way.
+- **Iterate after the first clone.** The first generation gets you 70% of the way. Use the prompting library's [refining recipes](./prompting-library.md#refining-an-existing-app) to push it the rest of the way.
 
 ## Next steps
 
-- [Prompting library](./guides/prompting-library.md) — more URL-based recipes (URL-only, URL with brand override, URL with content override).
-- [Visual editor and themes](./guides/visual-editor.md) — refine the cloned theme after generation.
-- [Connectors](./guides/connectors/index.md) — wire your cloned site into Forms, Analytics, or Single sign-on.
+- [Prompting library](./prompting-library.md) — more URL-based recipes (URL-only, URL with brand override, URL with content override).
+- [Visual editor and themes](./visual-editor.md) — refine the cloned theme after generation.
+- [Connectors](./connectors/index.md) — wire your cloned site into Forms, Analytics, or Single sign-on.

--- a/docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md
@@ -65,8 +65,3 @@ Vibe replaces sections rather than rebuilding everything. Useful when only part 
 - **Single-page references work best.** Most clones target one page. If you want a multi-page site, scaffold the first page from a URL, then use follow-up prompts to add additional pages.
 - **Iterate after the first clone.** The first generation gets you 70% of the way. Use the prompting library's [refining recipes](./prompting-library.md#refining-an-existing-app) to push it the rest of the way.
 
-## Next steps
-
-- [Prompting library](./prompting-library.md) — more URL-based recipes (URL-only, URL with brand override, URL with content override).
-- [Visual editor and themes](./visual-editor.md) — refine the cloned theme after generation.
-- [Connectors](./connectors/index.md) — wire your cloned site into Forms, Analytics, or Single sign-on.

--- a/docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md
@@ -1,5 +1,5 @@
 ---
-title: Cloning a reference site
+title: Cloning a Reference Site
 sidebar_position: 3
 unlisted: true
 ---

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/analytics.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/analytics.md
@@ -41,8 +41,3 @@ When your prompt mentions metrics, dashboards, or per-location cuts, Vibe's supe
 
 You don't need to "enable" the connector inside a prompt — turning it on once in Project Settings is enough. Describe what you want to see and Vibe handles the wiring.
 
-## Next steps
-
-- [Single sign-on](./single-sign-on.md) — gate the dashboard behind a member sign-in so the data has a clear scope.
-- [Forms](./forms.md) — pair submission counts and trends from your forms with the rest of the dashboard.
-- [Prompting library — Analytics](../prompting-library.md#connecting-to-analytics) — paste-ready prompts for owner dashboards, KPI tiles, and multi-location comparisons.

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/forms.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/forms.md
@@ -58,8 +58,3 @@ Forms inherit your application's theme automatically — primary color, border r
 
 Forms use structured style fields (background color, border, primary color, etc.) that pull from your theme, so visual consistency is the default.
 
-## Next steps
-
-- [Single sign-on](./single-sign-on.md) — gate forms behind a member sign-in.
-- [Analytics](./analytics.md) — surface submission counts and trends in a dashboard.
-- [Prompting library — Forms](../prompting-library.md#connecting-to-forms) — paste-ready prompts for contact forms, lead capture popups, and multi-step bookings.

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/index.md
@@ -18,10 +18,7 @@ There are three connectors today:
 
 Connectors are managed per project, in **Project Settings**. Open a project, click the settings icon in the toolbar, and scroll to **Shared connectors**. Toggle a connector on to make it available to every prompt in the project; toggle it off to remove it from the supervisor agent's options.
 
-<figure>
-  <img src="../../img/project-settings.png" alt="Vibe Project Settings page showing the Overview card and the Shared connectors section with Single sign-on, Forms, and Analytics each toggled on" />
-  <figcaption>Project Settings is where you turn connectors on and off. Each connector says what it does and whether it is enabled for the project.</figcaption>
-</figure>
+![Vibe Project Settings page showing the Overview card and the Shared connectors section with Single sign-on, Forms, and Analytics each toggled on](../../img/project-settings.png)
 
 When a connector is **enabled**, the supervisor agent can wire your generated UI into the underlying service automatically. When a connector is **disabled**, prompts that would normally activate it fall back to mocked or static behavior — useful when you want to design without committing to live integrations yet.
 

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/index.md
@@ -32,10 +32,3 @@ Most realistic apps use more than one connector. You don't need to declare them 
 
 That single prompt activates Forms (contact), Single sign-on (members area), and Analytics (owner dashboard). The supervisor agent identifies which connector each part of the request needs and wires the UI accordingly.
 
-## Next steps
-
-- [Single sign-on](./single-sign-on.md) — gate parts of your app behind member sign-in.
-- [Forms](./forms.md) — capture leads, contact requests, and structured submissions.
-- [Analytics](./analytics.md) — build dashboards wired to live data.
-- [Prompting library](../prompting-library.md) — concrete prompts grouped by connector.
-- [Error handling and troubleshooting](../troubleshooting.md) — what to do if a connector doesn't activate as expected.

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
@@ -48,8 +48,3 @@ The supervisor agent recognizes phrases like "sign in", "members area", "gated",
 
 Single sign-on pairs naturally with the [Analytics connector](./analytics.md) for member-specific data, and with the [Forms connector](./forms.md) when a form should be visible only to signed-in members.
 
-## Next steps
-
-- [Forms](./forms.md) — capture submissions from sign-in-gated pages.
-- [Analytics](./analytics.md) — show data scoped to the signed-in member.
-- [Prompting library — Single sign-on](../prompting-library.md#connecting-to-sso) — paste-ready prompts for member areas, gated pages, and profile views.

--- a/docusaurus/docs/business-app/ai/vibe/guides/image-generation.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/image-generation.md
@@ -46,7 +46,3 @@ If Vibe picks the wrong ratio, ask it to regenerate:
 - **Specify where it's going.** Telling Vibe the placement (hero banner, card thumbnail, profile photo) helps it pick the right aspect ratio without you having to ask explicitly.
 - **Iterate.** If the first image isn't right, ask for a regeneration with adjusted descriptions.
 
-## Next steps
-
-- [Prompting library — Generating images](./prompting-library.md#generating-images) — paste-ready prompts for hero photography, logos, and style-consistent illustration sets.
-- [Visual editor and themes](./visual-editor.md) — fine-tune the styling around generated images after the fact.

--- a/docusaurus/docs/business-app/ai/vibe/guides/plan-mode.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/plan-mode.md
@@ -63,9 +63,3 @@ A few patterns that produce fewer questions:
 
 If Vibe is confident it understands the request, it skips the questions and shows you a plan directly. You can still edit or cancel from there.
 
-## Next steps
-
-- [Prompting guide](./prompting.md) — write prompts that produce strong plans.
-- [Prompting library](./prompting-library.md) — concrete plan-friendly prompts you can paste.
-- [Visual editor and themes](./visual-editor.md) — make targeted changes without going through a full plan cycle.
-- [Error handling and troubleshooting](./troubleshooting.md) — what to do when something goes sideways during generation.

--- a/docusaurus/docs/business-app/ai/vibe/guides/prompting-library.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/prompting-library.md
@@ -196,9 +196,3 @@ What to expect: Vibe reverts the most recent edit. For a precise rollback, use t
 
 What to expect: Vibe surfaces the diff in chat. From there you can ask for a partial restore (keep one component from the checkpoint, leave the rest as-is).
 
-## Next steps
-
-- [Prompting guide](./prompting.md) for the principles behind these recipes.
-- [Connectors](./connectors/index.md) for what the Forms, Analytics, and Single sign-on connectors do under the hood.
-- [Image generation](./image-generation.md) for how Vibe creates hosted images from your prompts.
-- [Visual editor and themes](./visual-editor.md) for changes you make by clicking instead of typing.

--- a/docusaurus/docs/business-app/ai/vibe/guides/prompting-library.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/prompting-library.md
@@ -82,7 +82,7 @@ When you have a website you want to start from, paste its URL.
 
 > Build me a similar site to https://example.com
 
-What to expect: Vibe captures the page (screenshot, branding, layout, content), extracts colors and typography, and scaffolds a faithful clone. See the dedicated [clone-from-URL guide](../clone-from-url.md) for what gets captured and how.
+What to expect: Vibe captures the page (screenshot, branding, layout, content), extracts colors and typography, and scaffolds a faithful clone. See the dedicated [clone-from-URL guide](./clone-from-url.md) for what gets captured and how.
 
 ### URL with brand override
 

--- a/docusaurus/docs/business-app/ai/vibe/guides/prompting.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/prompting.md
@@ -153,9 +153,3 @@ Trust Vibe to handle the implementation. Focus on what you want the user to see 
 ### Massive All-at-Once Prompts
 Trying to build an entire complex application in a single prompt usually leads to worse results than building iteratively. Break it into logical pieces.
 
-## Next Steps
-
-- [Plan Mode](./plan-mode.md) — Use Plan mode for complex changes to review the approach before code is written
-- [Visual Editor & Themes](./visual-editor.md) — Make visual adjustments directly without writing prompts
-- [Connectors](./connectors/index.md) — Add forms, sign-in, and analytics to your application
-- [Image generation](./image-generation.md) — Add hosted images to your application from a prompt

--- a/docusaurus/docs/business-app/ai/vibe/guides/visual-editor.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/visual-editor.md
@@ -23,10 +23,7 @@ In Design mode, the left panel shows the **Themes** tab with:
 Available themes include:
 - Default, Glacier, Harvest, Lavender, Emerald, Coral, Midnight, Sand, Rose, Sunflower, Crimson, Slate, Ocean, and more.
 
-<figure>
-  <img src="../img/design-mode-themes.png" alt="Design mode Themes tab with Light selected, Default theme active, and the color palette list (Default, Glacier, Harvest, Lavender, Emerald) on the left next to the live application preview." />
-  <figcaption>The Design mode Themes tab pairs the Light/Dark toggle and color palette picker with a live preview of the changes.</figcaption>
-</figure>
+![Design mode Themes tab with Light selected, Default theme active, and the color palette list (Default, Glacier, Harvest, Lavender, Emerald) on the left next to the live application preview.](../img/design-mode-themes.png)
 
 ### Applying a Theme
 
@@ -47,10 +44,7 @@ When you select an element, Vibe gets exact context about what you clicked: the 
 
 You can select up to ten elements at once. Vibe handles each one in the same prompt.
 
-<figure>
-  <img src="../img/visual-editor-selected.png" alt="Hero headline selected in Design mode: a blue outline marks the element, an inline 'Ask Vibe' chat appears next to it, and the left Visual edits panel shows the element's tag, text content, layout, and color controls." />
-  <figcaption>Selecting a hero headline opens a small inline 'Ask Vibe' chat near the element and a full Visual edits panel on the left with text, layout, and color controls.</figcaption>
-</figure>
+![Hero headline selected in Design mode: a blue outline marks the element, an inline 'Ask Vibe' chat appears next to it, and the left Visual edits panel shows the element's tag, text content, layout, and color controls.](../img/visual-editor-selected.png)
 
 ### Two ways to ask for a change
 

--- a/docusaurus/docs/business-app/ai/vibe/guides/visual-editor.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/visual-editor.md
@@ -106,8 +106,3 @@ Both the visual editor and the main chat reach the same generation engine. The d
 
 The visual editor is best for *small, targeted adjustments anchored to something on screen*. For structural changes or anything that doesn't start from "this thing right here," the main chat is the right entry point.
 
-## Next Steps
-
-- [Prompting Guide](./prompting.md) — Write effective prompts for larger changes.
-- [Prompting library](./prompting-library.md) — Concrete prompts you can paste, including ones that pair well with element selection.
-- [Planning](./plan-mode.md) — Review the plan Vibe produces for any non-trivial change before it's applied.

--- a/docusaurus/docs/business-app/ai/vibe/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/index.md
@@ -19,21 +19,18 @@ Vibe turns natural language prompts into real, deployable web applications. Inst
 
 The entire process streams in real time, so you can watch your application take shape as the AI works.
 
-<figure>
-  <img src="./img/editor-overview.png" alt="The Vibe editor with a generated app: chat panel on the left showing the COMPLETED summary, live preview of the generated marketing site on the right, and Preview/Design/Code mode tabs at the top." />
-  <figcaption>The Vibe editor pairs a streaming chat panel with a live preview. After a successful run, the chat shows a `COMPLETED` block and the preview renders your application.</figcaption>
-</figure>
+![The Vibe editor with a generated app: chat panel on the left showing the COMPLETED summary, live preview of the generated marketing site on the right, and Preview/Design/Code mode tabs at the top.](./img/editor-overview.png)
 
 ## Key Features
 
 ### Chat-Based Development
-Describe what you want in the chat panel. Vibe interprets your request and generates or modifies your application. You can iterate by sending follow-up messages to refine the result.
+Describe what you want in the chat panel. Vibe interprets the request and generates or modifies the application. Send follow-up messages to refine the result. Vibe's chat supports multiple languages, including French, Spanish, German, Italian, Czech, Chinese, Japanese, and Korean.
 
 ### Planning
 Every generation produces a structured plan that drives the run. The plan, the architecture, and the file list are captured in the `COMPLETED` block at the end of each run so you can verify what was built. See [Planning](./guides/plan-mode.md).
 
 ### Cloning a reference site
-Paste a URL and Vibe captures the screenshot, branding, layout, and content of that page, then scaffolds a faithful clone you can refine. The captured colors become a custom theme automatically. See [Cloning a reference site](./clone-from-url.md).
+Paste a URL and Vibe captures the screenshot, branding, layout, and content of that page, then scaffolds a faithful clone you can refine. The captured colors become a custom theme automatically. See [Cloning a reference site](./guides/clone-from-url.md).
 
 ### Visual Editor & Themes
 Switch to Design mode to browse pre-built color themes, toggle between light and dark mode, and make targeted edits by clicking elements in the preview. When you click an element, Vibe gets exact source context (file, line, JSX tag, classes), so any change you ask for lands precisely on the element you selected. See [Visual editor and themes](./guides/visual-editor.md).
@@ -80,14 +77,41 @@ Applications built with Vibe use:
 - **shadcn/ui** component library (50+ pre-built components)
 - **Lucide** icons
 
-## Next Steps
+## Frequently Asked Questions
 
-- [Getting Started](./getting-started.md) — Create your first project.
-- [Cloning a reference site](./clone-from-url.md) — Start from an existing site by pasting its URL.
-- [Prompting Guide](./guides/prompting.md) — The principles behind effective prompts.
-- [Prompting library](./guides/prompting-library.md) — Concrete prompts you can paste, organized by intent.
-- [Visual Editor & Themes](./guides/visual-editor.md) — Customize your application's look.
-- [Planning](./guides/plan-mode.md) — How a generation flows through plan, build, validate, fix, complete.
-- [Connectors](./guides/connectors/index.md) — Wire your app into Forms, Single sign-on, and Analytics.
-- [Image generation](./guides/image-generation.md) — Produce hosted images on demand from your prompts.
-- [Error handling and troubleshooting](./guides/troubleshooting.md) — How auto-fix works and what to do when it doesn't.
+<details>
+<summary>Do I need coding experience to use Vibe?</summary>
+
+No. You describe what you want in plain English and Vibe handles the code. If you want to make manual edits, Code mode gives you direct access to the source files.
+
+</details>
+
+
+<details>
+<summary>Can I start from an existing website?</summary>
+
+Yes. Paste any URL into the chat input and Vibe captures the page's screenshot, branding, layout, and content, then scaffolds a clone you can refine. See [Cloning a reference site](./guides/clone-from-url.md).
+
+</details>
+
+<details>
+<summary>What if Vibe misunderstands my request?</summary>
+
+When a prompt is ambiguous, Vibe pauses and asks clarifying questions before generating. If the result isn't what you wanted, send a follow-up prompt to correct it or restore a previous checkpoint.
+
+</details>
+
+<details>
+<summary>How do I undo a change I don't like?</summary>
+
+Vibe creates checkpoints automatically as you iterate. Open the Checkpoints panel from the toolbar to view diffs and restore any previous version.
+
+</details>
+
+<details>
+<summary>What languages can I use in the chat?</summary>
+
+Vibe's chat supports multiple languages, including French, Spanish, German, Italian, Czech, Chinese, Japanese, and Korean.
+
+</details>
+


### PR DESCRIPTION
## Summary

- Renamed `introduction.md` to `index.md` and added `_category_.json` to capitalize Vibe in the sidebar and set it to position 3 under AI
- Added `_category_.json` for the Guides subfolder with capitalized label and moved `clone-from-url.md` into it
- Converted all `<figure>/<img>` HTML blocks to standard Markdown image syntax to fix broken images
- Updated the intro page: added language support info to Chat-Based Development, replaced Next Steps with a collapsible FAQ section
- Fixed `knowledge-base.md` sidebar position conflict with Vibe

## Test plan

- [ ] Vibe appears 3rd in the AI sidebar, capitalized
- [ ] Guides subfolder is capitalized in the sidebar
- [ ] All images load on the Vibe intro, Getting Started, Visual Editor, and Connectors pages
- [ ] FAQs are collapsible at the bottom of the intro page
- [ ] All internal links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)