### PR TITLE
docs: list Vibe intro page and add Next Steps section

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/index.md
@@ -1,7 +1,6 @@
 ---
 title: Introduction to Vibe
 sidebar_position: 1
-unlisted: true
 ---
 
 # Introduction to Vibe
@@ -115,3 +114,14 @@ Vibe's chat supports multiple languages, including French, Spanish, German, Ital
 
 </details>
 
+## Next Steps
+
+- [Getting Started](./getting-started.md) — Create your first app and learn the basics
+- [Prompting Guide](./guides/prompting.md) — Write prompts that get better results
+- [Cloning a Reference Site](./guides/clone-from-url.md) — Scaffold an app from any URL
+- [Visual Editor & Themes](./guides/visual-editor.md) — Apply themes and edit elements visually
+- [Planning](./guides/plan-mode.md) — Understand how Vibe plans before it builds
+- [Image Generation](./guides/image-generation.md) — Generate hosted images in your app
+- [Connectors](./guides/connectors/index.md) — Wire your app into forms, analytics, and sign-on
+- [Prompting Library](./guides/prompting-library.md) — Ready-made prompts for common use cases
+- [Troubleshooting](./guides/troubleshooting.md) — Fix common errors and unexpected behavior


### PR DESCRIPTION
## Summary

- Removes `unlisted: true` from the Vibe intro page so it appears in the sidebar
- Adds a Next Steps section at the bottom of the intro linking to all guide pages (which remain unlisted)

## Test plan

- [ ] Verify Vibe appears in the sidebar under AI
- [ ] Verify guide pages are not visible in the sidebar
- [ ] Verify all Next Steps links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)