### PR TITLE
docs: restore Next Steps sections to all Vibe guide pages

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/getting-started.md
+++ b/docusaurus/docs/business-app/ai/vibe/getting-started.md
@@ -139,3 +139,9 @@ The top-right toolbar provides:
 - **Paste a URL** — If a website you like is closer to your target than words can describe, paste its URL and Vibe will clone the look and structure as a starting point.
 - **Read the COMPLETED block** — The collapsible "Architecture & Navigation" and "Files" details show what shipped. After a big change, expanding them is the fastest way to confirm Vibe interpreted your prompt the way you meant it.
 
+## Next Steps
+
+- [Prompting Guide](./guides/prompting.md) — Learn the principles behind effective prompts
+- [Visual Editor & Themes](./guides/visual-editor.md) — Apply themes and make targeted edits without prompts
+- [Planning](./guides/plan-mode.md) — Understand how Vibe plans before it builds
+

--- a/docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md
@@ -65,3 +65,9 @@ Vibe replaces sections rather than rebuilding everything. Useful when only part 
 - **Single-page references work best.** Most clones target one page. If you want a multi-page site, scaffold the first page from a URL, then use follow-up prompts to add additional pages.
 - **Iterate after the first clone.** The first generation gets you 70% of the way. Use the prompting library's [refining recipes](./prompting-library.md#refining-an-existing-app) to push it the rest of the way.
 
+## Next Steps
+
+- [Visual Editor & Themes](./visual-editor.md) — Apply a different theme or tweak elements in your cloned app
+- [Prompting Library](./prompting-library.md) — Refining recipes for polishing a clone after the first generation
+- [Connectors](./connectors/index.md) — Wire your cloned app into forms, analytics, and sign-on
+

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/analytics.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/analytics.md
@@ -41,3 +41,9 @@ When your prompt mentions metrics, dashboards, or per-location cuts, Vibe's supe
 
 You don't need to "enable" the connector inside a prompt — turning it on once in Project Settings is enough. Describe what you want to see and Vibe handles the wiring.
 
+## Next Steps
+
+- [Connectors](./index.md) — Overview of all connectors and how to combine them
+- [Single sign-on](./single-sign-on.md) — Gate your analytics dashboard behind a sign-in screen
+- [Prompting Library](../prompting-library.md) — Ready-made dashboard prompts organized by use case
+

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/forms.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/forms.md
@@ -58,3 +58,9 @@ Forms inherit your application's theme automatically — primary color, border r
 
 Forms use structured style fields (background color, border, primary color, etc.) that pull from your theme, so visual consistency is the default.
 
+## Next Steps
+
+- [Connectors](./index.md) — Overview of all connectors and how to combine them
+- [Single sign-on](./single-sign-on.md) — Gate a form behind a sign-in screen
+- [Prompting Library](../prompting-library.md) — Ready-made form prompts organized by use case
+

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/index.md
@@ -32,3 +32,10 @@ Most realistic apps use more than one connector. You don't need to declare them 
 
 That single prompt activates Forms (contact), Single sign-on (members area), and Analytics (owner dashboard). The supervisor agent identifies which connector each part of the request needs and wires the UI accordingly.
 
+## Next Steps
+
+- [Forms](./forms.md) — Capture contact form and lead submissions from your app
+- [Single sign-on](./single-sign-on.md) — Gate a members area with existing customer accounts
+- [Analytics](./analytics.md) — Surface multi-location metrics for signed-in users
+- [Prompting Library](../prompting-library.md) — Ready-made prompts for each connector
+

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
@@ -48,3 +48,9 @@ The supervisor agent recognizes phrases like "sign in", "members area", "gated",
 
 Single sign-on pairs naturally with the [Analytics connector](./analytics.md) for member-specific data, and with the [Forms connector](./forms.md) when a form should be visible only to signed-in members.
 
+## Next Steps
+
+- [Connectors](./index.md) — Overview of all connectors and how to combine them
+- [Analytics](./analytics.md) — Surface member-specific metrics behind your sign-in gate
+- [Prompting Library](../prompting-library.md) — Ready-made SSO prompts for members areas and gated content
+

--- a/docusaurus/docs/business-app/ai/vibe/guides/image-generation.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/image-generation.md
@@ -46,3 +46,9 @@ If Vibe picks the wrong ratio, ask it to regenerate:
 - **Specify where it's going.** Telling Vibe the placement (hero banner, card thumbnail, profile photo) helps it pick the right aspect ratio without you having to ask explicitly.
 - **Iterate.** If the first image isn't right, ask for a regeneration with adjusted descriptions.
 
+## Next Steps
+
+- [Visual Editor & Themes](./visual-editor.md) — Fine-tune how images fit into your design
+- [Prompting Library](./prompting-library.md) — See image generation prompts organized by use case
+- [Connectors](./connectors/index.md) — Add live data alongside your generated visuals
+

--- a/docusaurus/docs/business-app/ai/vibe/guides/plan-mode.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/plan-mode.md
@@ -63,3 +63,9 @@ A few patterns that produce fewer questions:
 
 If Vibe is confident it understands the request, it skips the questions and shows you a plan directly. You can still edit or cancel from there.
 
+## Next Steps
+
+- [Prompting Guide](./prompting.md) — Write specific prompts that produce cleaner plans with fewer questions
+- [Troubleshooting](./troubleshooting.md) — What to do when a generation doesn't go as planned
+- [Getting Started](../getting-started.md) — Walk through a full generation end to end
+

--- a/docusaurus/docs/business-app/ai/vibe/guides/prompting-library.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/prompting-library.md
@@ -196,3 +196,9 @@ What to expect: Vibe reverts the most recent edit. For a precise rollback, use t
 
 What to expect: Vibe surfaces the diff in chat. From there you can ask for a partial restore (keep one component from the checkpoint, leave the rest as-is).
 
+## Next Steps
+
+- [Prompting Guide](./prompting.md) — The principles behind why these prompts work
+- [Cloning a Reference Site](./clone-from-url.md) — Use a URL as your starting point instead of a prompt
+- [Connectors](./connectors/index.md) — Understand the connectors several of these prompts activate
+

--- a/docusaurus/docs/business-app/ai/vibe/guides/prompting.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/prompting.md
@@ -153,3 +153,9 @@ Trust Vibe to handle the implementation. Focus on what you want the user to see 
 ### Massive All-at-Once Prompts
 Trying to build an entire complex application in a single prompt usually leads to worse results than building iteratively. Break it into logical pieces.
 
+## Next Steps
+
+- [Prompting Library](./prompting-library.md) — Ready-made prompts organized by intent you can paste and adapt
+- [Cloning a Reference Site](./clone-from-url.md) — Use a URL as your starting point instead of describing from scratch
+- [Visual Editor & Themes](./visual-editor.md) — Make targeted element-level edits without writing a prompt
+

--- a/docusaurus/docs/business-app/ai/vibe/guides/troubleshooting.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/troubleshooting.md
@@ -131,3 +131,9 @@ If a problem persists after auto-fix, manual prompts, and a checkpoint restore:
 - Refresh the page and re-send your prompt as a fresh attempt.
 - Restore the last checkpoint where things were working and try a smaller step from there.
 - Reach out to your trusted-tester program contact with what you tried and what error you saw.
+
+## Next Steps
+
+- [Planning](./plan-mode.md) — Understand how Vibe plans so you can catch misalignments early
+- [Prompting Guide](./prompting.md) — Write clearer prompts that produce fewer errors
+- [Getting Started](../getting-started.md) — Review the full generation flow end to end

--- a/docusaurus/docs/business-app/ai/vibe/guides/visual-editor.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/visual-editor.md
@@ -106,3 +106,9 @@ Both the visual editor and the main chat reach the same generation engine. The d
 
 The visual editor is best for *small, targeted adjustments anchored to something on screen*. For structural changes or anything that doesn't start from "this thing right here," the main chat is the right entry point.
 
+## Next Steps
+
+- [Prompting Guide](./prompting.md) — Write effective prompts for changes that go beyond the visual editor
+- [Connectors](./connectors/index.md) — Wire your app into forms, analytics, and sign-on
+- [Prompting Library](./prompting-library.md) — Ready-made prompts for common refinements
+


### PR DESCRIPTION
## Summary

- Adds Next Steps sections back to all 12 Vibe guide pages
- Each page links to 3–4 contextually relevant follow-on reads
- All guide pages remain unlisted; links in Next Steps are the intended navigation path

## Test plan

- [ ] Verify Next Steps links resolve correctly on each page
- [ ] Verify all guide pages remain unlisted (not visible in sidebar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)