### PR TITLE
docs: add beta/trusted tester callout to Vibe intro page

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/index.md
@@ -5,6 +5,10 @@ sidebar_position: 1
 
 # Introduction to Vibe
 
+:::warning Beta feature
+Vibe is currently available to trusted testers only. If you're interested in early access, contact your account representative.
+:::
+
 Vibe is an AI-powered application builder. Describe what you want in plain English, and Vibe generates a fully functional React application — complete with components, routing, styling, and a live preview.
 
 ## What is Vibe?


### PR DESCRIPTION
## Summary

- Adds a warning callout to the top of the Vibe intro page noting the feature is in beta and available to trusted testers only

## Test plan

- [ ] Verify the callout renders in yellow/orange on the Vibe intro page

🤖 Generated with [Claude Code](https://claude.com/claude-code)