### PR TITLE
docs: add product-brief skill and apply sprint updates

### DIFF
--- a/.claude/skills/product-brief/SKILL.md
+++ b/.claude/skills/product-brief/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: product-brief
+description: Ingests a weekly CPO product brief and updates all relevant Business App documentation. Filters for client-facing, released features only. Asks before documenting anything with unclear release status.
+---
+
+# Product Brief Ingestion
+
+Reads a weekly product brief and translates shipped features into documentation updates — new articles, edits to existing pages, or both — while strictly filtering out internal, partner-only, and unreleased content.
+
+## When to Use
+
+Use this skill when:
+- The weekly CPO product brief has been shared and needs to be reflected in docs
+- A user says "update docs from the product brief" or "ingest the brief"
+
+## Step-by-Step Workflow
+
+### Step 1: Parse the brief
+
+Read the full brief. For every feature or update mentioned, extract:
+
+- **Name**: What the feature is called
+- **Section**: Which product area or team owns it (AI Experience, Platform, Vibe, Ads, etc.)
+- **Release status**: What label or language signals its state (see Status Reference below)
+- **Audience**: Who it's for (SMB users, partners/admins only, internal teams, infrastructure)
+- **Description**: What it does from a user's perspective
+
+### Step 2: Filter ruthlessly
+
+Discard anything that matches **any** of the following. Do NOT include these in docs — not even a mention:
+
+**Internal / infrastructure (always discard):**
+- Backend services, databases, API layers, Kubernetes, observability/monitoring, CI/CD
+- SOC2, security audits, compliance certifications
+- SDK changes, gRPC, developer portal, internal tooling
+- Anything described as "internal-only", "behind a feature flag", or "for engineers"
+- Migration work (data migrations, archival syncs, infrastructure upgrades) unless it changes something visible to users
+- Analytics tools the user cannot see (Posthog, Datadog, etc.)
+
+**Partner/reseller-only (always discard):**
+- Features that only exist in Partner Center
+- Account template creation and management (partners build templates; SMBs receive the results — do not document the creation side)
+- Anything requiring admin console or partner-level access
+- Whitelabel, reseller, or agency framing
+- References to "partners", "resellers", "agencies", "white-label"
+
+**Unreleased (hold for confirmation — see Step 3):**
+- `TESTING`, `TRUSTED TESTER`, `IN PROGRESS`, `DISCOVERY`, `NEXT`, `COMING SOON`
+- Lowercase `in progress`, `next`, `discovery` status indicators
+- Language like "in trusted testing", "launching next sprint", "currently in testing", "we're working on", "will be released", "expected by end of month", "estimated to start", "kicking off"
+- Features the brief says are "planned" or "in the roadmap"
+
+**Keep (proceed to document):**
+- Explicitly `RELEASED` or `released`/`complete` (lowercase) features
+- Features described as live, shipped, or in production with no caveats
+- Features where the brief says "now available", "shipped this sprint", "now live", or equivalent
+
+### Step 3: Confirm unclear items before writing
+
+Before making any changes, present the user with a categorized summary:
+
+```
+## Product Brief Analysis
+
+### Ready to document (released, client-facing)
+- [Feature name]: [one-line description of what changed] → [target doc path or "new article needed"]
+- ...
+
+### Needs your input — release status unclear
+- [Feature name]: [quote the exact language from the brief that is ambiguous]
+  → Is this released and available to all Business App users? (y/n)
+- ...
+
+### Skipped (not client-facing or not released)
+- [Feature name]: [reason — internal / partner-only / unreleased]
+- ...
+```
+
+Wait for the user to respond to the "Needs your input" section before writing anything. Do not assume or guess. If the user says something is released, proceed. If they say it is not, add it to the skipped list.
+
+### Step 4: Map confirmed items to docs
+
+For each confirmed item, determine whether it:
+
+**A) Adds to or modifies an existing article** — use the doc map below to find the right file, then make a targeted edit. Do not rewrite the whole article; add or update only what changed.
+
+**B) Describes a feature with no existing article** — create a new article using the `generate-help-article` skill.
+
+**C) Adds a new section to an existing article** — insert it in the right location without restructuring surrounding content.
+
+#### Doc map — feature area to file
+
+| Feature area | Primary doc(s) |
+|---|---|
+| Users / team management | `docusaurus/docs/business-app/administration/users.md` |
+| Connections / integrations | `docusaurus/docs/business-app/administration/connections/index.md` |
+| Automations | `docusaurus/docs/business-app/automations/` |
+| Automation steps / actions | `docusaurus/docs/business-app/automations/automation-steps.mdx` |
+| Automation triggers | `docusaurus/docs/business-app/automations/automation-triggers.md` |
+| Campaigns (email/SMS) | `docusaurus/docs/business-app/campaigns/` |
+| SMS campaigns | `docusaurus/docs/business-app/campaigns/sms-campaigns.mdx` |
+| Conversations AI / AI receptionist | `docusaurus/docs/business-app/conversations/conversations-ai/` |
+| AI Sales Assistant / CRM AI | `docusaurus/docs/business-app/ai/ai-workforce/ai-sales-assistant.mdx` |
+| AI Reputation Specialist | `docusaurus/docs/business-app/ai/ai-workforce/ai-reputation-specialist.md` |
+| AI Voice Receptionist | `docusaurus/docs/business-app/ai/ai-workforce/ai-voice-receptionist.md` |
+| AI Chat Receptionist | `docusaurus/docs/business-app/ai/ai-workforce/ai-chat-receptionist/` |
+| AI workforce overview | `docusaurus/docs/business-app/ai/ai-workforce/ai_workforce_overview.md` |
+| Vibe (website builder) | `docusaurus/docs/business-app/ai/vibe/` |
+| Vibe visual editor | `docusaurus/docs/business-app/ai/vibe/guides/visual-editor.md` |
+| Vibe cloning | `docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md` |
+| CRM companies | `docusaurus/docs/business-app/crm/companies.md` |
+| CRM contacts | `docusaurus/docs/business-app/crm/contacts/index.md` |
+| CRM forms | `docusaurus/docs/business-app/crm/forms/index.md` |
+| Executive Report | `docusaurus/docs/business-app/executivereport/` |
+| Knowledge base | `docusaurus/docs/business-app/ai/knowledge-base.md` |
+| Administration overview | `docusaurus/docs/business-app/administration/index.mdx` |
+
+If a feature does not map to any existing doc, create a new article. Use `generate-help-article` for the full structure.
+
+### Step 5: Write the updates
+
+For each item:
+
+1. **Read the target file** before editing (never edit without reading first)
+2. **Make the minimum necessary change**: add a new section, update a paragraph, or add to an existing list
+3. **Apply all content rules** (see Rules section below)
+4. **Do not restructure existing content** unless it is broken
+5. **Do not add screenshots** unless you have the actual image path — use a placeholder comment `<!-- screenshot needed: [description] -->` instead
+6. For **new articles**, follow the `generate-help-article` skill exactly
+
+After all edits are complete, tell the user:
+- Which files were changed
+- What was added or updated in each file
+- Which items still need screenshots
+
+### Step 6: Run pre-push validation
+
+After all edits, invoke the `pre-push-validation` skill on every modified file. Fix any errors before reporting completion.
+
+---
+
+## Content Rules (apply to every word written)
+
+### Audience
+Write for **small and medium-sized business owners**. They use Business App to run their business. They do not manage partners, configure systems for other businesses, or see Partner Center.
+
+### Gray-label (zero tolerance)
+- Never write "Vendasta", "Partner Center", "partner", "reseller", "agency", "white-label"
+- Use "Business App" or the specific product name
+- If a feature exists in Partner Center but also in Business App, document only the Business App side
+
+### Evergreen content
+- Write only about the current, live state of the product
+- Never write "previously", "formerly", "used to", "before this update", "now supports", "we've added", "you can now", "recently added", "new feature"
+- If a change must be described, describe the current state only: "The Users page displays..." not "We've updated the Users page to display..."
+
+### Voice and tense
+- Present tense only: "The Users page displays..." not "The Users page will display..."
+- Second person: "you", "your business" — never "users", "the user", "businesses"
+- Neutral, helpful, calm — no marketing language (no "powerful", "seamless", "game-changing", "innovative", "amazing")
+
+### Source fidelity
+- Write only what is explicitly described in the brief or existing documentation
+- Never infer, assume, or add detail not present in source material
+- If you are unsure what a feature does from the user's perspective, ask rather than guess
+
+---
+
+## Status Reference — Reading the Brief
+
+Briefs use inconsistent formatting for release status. Use this lookup table:
+
+| If the brief says... | Treat as... |
+|---|---|
+| `RELEASED` | Released — document |
+| `released` (lowercase) | Released — document |
+| `complete` / `Complete` (on a checklist) | Released — document |
+| "now live", "shipped", "launched", "went live", "in production" | Released — document |
+| "shipped this sprint" with no qualification | Released — document |
+| `TESTING` | Not released — ask |
+| `TRUSTED TESTER` / `trusted tester` | Not released — ask |
+| `IN PROGRESS` / `in progress` | Not released — skip |
+| `NEXT` / `next` | Not released — skip |
+| `DISCOVERY` / `discovery` | Not released — skip |
+| `coming soon`, `on the roadmap`, `planned` | Not released — skip |
+| "we expect", "estimated", "will be", "about to", "upcoming" | Not released — skip |
+| "end of the month", "next sprint", "launching May 7" | Not released — ask (confirm date has passed) |
+| `in progress` on a capability checklist | Not released — skip that specific capability |
+
+When in doubt, ask. Never document something as released unless you are certain.
+
+---
+
+## What to Never Document
+
+Regardless of release status, never write about:
+
+- Internal metrics: ARR, MRR, WAB counts, churn data, revenue figures
+- Competitor comparisons or benchmarks
+- Launch events, press releases, or external campaigns
+- Named enterprise customers or partner deployments (e.g., do not name "Italiaonline" or "MARiO")
+- Vendor or supplier names (Twilio, Vertex AI, Recall AI, etc.) unless they are directly relevant to a user-facing integration the user must configure
+- AI model names or infrastructure details (GPT, Gemini, Claude, gVisor, etc.)
+- Internal team names (Psychobillers, Meerkats, NP-easy, etc.)
+- Internal codenames or project names (DALE, MCQL, CASA, BMO, etc.) unless they appear as user-facing labels
+- Staff names or @mentions
+- Self-signup or migration context ("Broadly users transitioning to Business App", etc.)
+
+---
+
+## Example — Applying the Skill
+
+Given this excerpt from a brief:
+
+> **User Management improvements** `RELEASED`: Renamed "Users" permission to "User Management" and placed it at the top of the permissions list. Cleaned up the table: left-aligned columns, merged first/last name into a single column, added user profile images. SMB users can now edit another team member's info via a new "Edit User" dropdown option, including an automatic email verification flow when an email is changed.
+
+**Parse:**
+- Feature: User management table and permission updates
+- Status: RELEASED
+- Audience: SMB users (they manage their team in Business App)
+- Target doc: `docusaurus/docs/business-app/administration/users.md`
+
+**What to update in users.md:**
+- The "View users" section describes columns as Email, First Name, Last Name, Phone — update to reflect the merged Name column and profile images
+- The actions menu description should include "Edit User" (or confirm it matches the existing "Edit Profile" option)
+- If "User Management" permission is now the name and appears at the top of the list, update any reference to "Users" permission in the permissions section
+
+**What NOT to write:**
+- Do not say "previously called 'Users'", "renamed", or "we've updated"
+- Do not mention that the change was made this sprint
+- Do not mention the motivation (Broadly migration)
+- Write only the current state: "The Users page displays a table with each team member's profile image, name, email, and phone."
+
+---
+
+## Checklist Before Closing
+
+- [ ] Brief fully parsed — no section skipped
+- [ ] Unclear items confirmed with user before writing
+- [ ] Only released, client-facing content documented
+- [ ] No Vendasta branding, no partner language, no internal references
+- [ ] No evergreen violations (no "previously", "new", "now", "recently", "updated")
+- [ ] All target files read before editing
+- [ ] New articles follow `generate-help-article` structure
+- [ ] Screenshot placeholders added where images are needed
+- [ ] Pre-push validation passed on all modified files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ Read the full SKILL.md file before using each skill.
 | `generate-help-article` | Creating any new feature documentation page |
 | `getting-started-guide` | Creating or editing a Getting Started guide |
 | `pre-push-validation` | Before every commit — catches errors that break the build |
+| `product-brief` | Ingesting a weekly CPO product brief and updating all relevant docs |
 | `training-video-teleprompter` | Turning a doc into a teleprompter script for video |
 | `what-did-i-get-done` | Summarizing recent commits for a status update |
 | `style-review` | Reviewing docs for style, voice, gray-label, and formatting violations |

--- a/docusaurus/docs/business-app/administration/users.md
+++ b/docusaurus/docs/business-app/administration/users.md
@@ -1,32 +1,31 @@
 ---
-title: Users
-sidebar_label: Users
+title: User Management
+sidebar_label: User Management
 description: View, invite, and manage users and their permissions in your Business App.
 sidebar_position: 3
 tags: [users, permissions, team, administration]
-keywords: [users, invite user, permissions, team members, remove user, edit permissions]
+keywords: [users, invite user, permissions, team members, remove user, edit permissions, user management]
 ---
 
-The **Users** page lets you manage who has access to your Business App. You can view all current users, invite new team members, set permissions for each person, and remove users who no longer need access.
+The **User Management** page lets you manage who has access to your Business App. You can view all current users, invite new team members, set permissions for each person, and remove users who no longer need access.
 
-To open this page, go to `Administration` > `Users`.
+To open this page, go to `Administration` > `User Management`.
 
 ![The Users page showing a table of team members with options to invite, edit permissions, or remove users](./img/users-list.png)
 
 ## View users
 
-The Users page displays a table of everyone who has access to your Business App. Each row shows the user's:
+The User Management page displays a table of everyone who has access to your Business App. Each row shows the user's profile image and:
 
 - **Email**
-- **First Name**
-- **Last Name**
+- **Name**
 - **Phone**
 
-Each row also has an actions menu (three dots) with options to **Edit Profile**, **Edit Permissions**, or **Remove user**.
+Each row also has an actions menu (three dots) with options to **Edit contact info**, **Edit Permissions**, or **Remove user**.
 
 ## Invite a user
 
-1. On the **Users** page, click **Invite user**.
+1. On the **User Management** page, click **Invite user**.
 2. In the **Add team member** sidebar, fill in the following fields:
    - **First name** (optional)
    - **Last name** (optional)
@@ -43,7 +42,7 @@ The invited user receives a welcome email with instructions to access your Busin
 
 You can change which tabs a user can access at any time.
 
-1. On the **Users** page, find the user you want to update.
+1. On the **User Management** page, find the user you want to update.
 2. Click the actions menu (three dots) on that user's row.
 3. Select **Edit Permissions**.
 4. Check or uncheck tabs to adjust what this user can see.
@@ -55,13 +54,13 @@ Changes take effect immediately.
 The tabs available in the permissions list match the tabs configured for your Business App. If a tab does not appear in the list, it is not enabled for your account.
 :::
 
-## Edit a user's profile
+## Edit a user's contact info
 
-If you have **User Management** permissions, you can update another team member's profile details on their behalf — including their name, email, and phone number.
+If you have **User Management** permissions, you can update another team member's contact details on their behalf — including their name, email, and phone number.
 
-1. On the **Users** page, find the user whose profile you want to update.
+1. On the **User Management** page, find the user whose information you want to update.
 2. Click the actions menu (three dots) on that user's row.
-3. Select **Edit Profile**.
+3. Select **Edit contact info**.
 4. In the sidebar, update any of the following fields:
    - **First name**
    - **Last name**
@@ -73,7 +72,7 @@ Changes take effect immediately. Users can also update their own profile details
 
 ## Remove a user
 
-1. On the **Users** page, find the user you want to remove.
+1. On the **User Management** page, find the user you want to remove.
 2. Click the actions menu (three dots) on that user's row.
 3. Select **Remove user**.
 4. In the confirmation dialog, review the user's name and click **Remove user** to confirm.
@@ -85,9 +84,9 @@ Removing a user cannot be undone. The user immediately loses access to your Busi
 ## Frequently Asked Questions (FAQs)
 
 <details>
-<summary>Where do I find the Users page?</summary>
+<summary>Where do I find the User Management page?</summary>
 
-Go to `Administration` > `Users`. The URL ends with `administration/users` after your business ID.
+Go to `Administration` > `User Management`. The URL ends with `administration/users` after your business ID.
 
 </details>
 
@@ -108,7 +107,7 @@ Permissions control which tabs a user can see in Business App. For example, you 
 <details>
 <summary>Can I edit a user's information after inviting them?</summary>
 
-Yes. If you have **User Management** permissions, you can update another team member's profile details — including their name, email, and phone number — by selecting **Edit Profile** from the actions menu on their row. You can also update their permissions at any time. Users can also edit their own profile details from their account settings.
+Yes. If you have **User Management** permissions, you can update another team member's contact details — including their name, email, and phone number — by selecting **Edit contact info** from the actions menu on their row. You can also update their permissions at any time. Users can also edit their own profile details from their account settings.
 
 </details>
 

--- a/docusaurus/docs/business-app/ai/ai-workforce/ai-sales-assistant.mdx
+++ b/docusaurus/docs/business-app/ai/ai-workforce/ai-sales-assistant.mdx
@@ -52,6 +52,7 @@ The AI Sales Assistant addresses these challenges by automating CRM updates and 
 - **Automated CRM updates**: Automatically update CRM contact, company, opportunity, and custom object records after customer meetings and calls, or on a schedule using the automation time trigger. Configure which fields the AI can update and how it handles existing values.
 - **Conversational CRM insights**: Ask natural-language questions to get specific, company-level insights from your CRM data and meeting content — no need to run reports or search through records manually
 - **Activity creation**: Create sales activities directly from the AI Sales Assistant based on meeting outcomes and CRM data, helping you stay on top of follow-ups and next steps
+- **Company profile summary**: An AI-generated summary appears directly in the associations panel on each company profile, giving you a quick overview of the company without opening the chat
 
 :::info
 The AI Sales Assistant uses data from your meeting recordings and CRM records to power its insights and automated updates. Conversation Intelligence captures conversation details, summaries, and action items that the assistant uses to keep your CRM accurate.
@@ -133,10 +134,11 @@ Add relevant knowledge base content to help the AI Sales Assistant provide more 
 
 ### Step 4: Start using the AI Sales Assistant
 
-Once configured, the AI Sales Assistant works in two ways:
+Once configured, the AI Sales Assistant works in three ways:
 
 - **Automated updates**: After meetings are recorded and analyzed, the AI Sales Assistant automatically updates your CRM records based on the conversation content. No action is required from you.
 - **On-demand chat**: Open the AI Sales Assistant chat by clicking the AI icon in the top right of the CRM screen. Ask questions about your CRM data, meeting outcomes, or company details to get instant answers.
+- **Company profile summary**: An AI-generated summary appears in the associations panel on each company profile. You can review key details about a company without opening the chat.
 
 ## CRM AI editions
 

--- a/docusaurus/docs/business-app/campaigns/sms-campaigns.mdx
+++ b/docusaurus/docs/business-app/campaigns/sms-campaigns.mdx
@@ -42,7 +42,8 @@ SMS add-ons are only available in the United States and Canada.
 ### SMS content
 
 1. Enter the **Message Text** for your audience. Keep in mind SMS character limits.
-2. Use the preview to see how the message looks on mobile.
+2. (Optional) Add an image to your message. You can add, edit, delete, and preview the image in both the step configuration and the recipient preview.
+3. Use the preview to see how the message looks on mobile.
 
 ![SMS content editor](./img/sms-campaigns/25981173759511.jpg)
 

--- a/docusaurus/docs/business-app/conversations/conversations-ai/index.mdx
+++ b/docusaurus/docs/business-app/conversations/conversations-ai/index.mdx
@@ -23,7 +23,7 @@ Together, these components create an intelligent receptionist that knows your bu
 
 - **[AI Website Knowledge Training](./ai-website-knowledge-training)** - Train your AI on website content and business information
 - **[Customizing Your Chatbot Behavior](./customizing-your-chatbot-behavior)** - Configure AI personality and response style
-- **[Set up Conversations for web chat](../setup/conversations-ai-web-chat-overview)** - Set up intelligent web chat for your website
+- **[Set up Conversations for web chat](../web-chat/)** - Set up intelligent web chat for your website
 
 ## AI Receptionist Capabilities
 
@@ -159,6 +159,12 @@ The AI assistant accesses your business profile information (location, hours, se
 <summary><strong>How will I know if I received a message?</strong></summary>
 
 New messages appear live in Business App without page refreshing. You can receive instant email notifications for new messages or daily digest emails.
+</details>
+
+<details>
+<summary><strong>What language are conversation summaries written in?</strong></summary>
+
+Conversation summaries in email notifications are generated in the primary language of your business's city. This ensures that summaries are readable to you and your team regardless of the language a customer used during the conversation.
 </details>
 
 <details>


### PR DESCRIPTION
Adds a new /product-brief Claude skill that ingests weekly CPO briefs and updates docs with released, client-facing features only. The skill filters out internal, partner-only, and unreleased content, and asks for confirmation on anything with unclear release status.

Applied this week's brief:
- administration/users.md: rename to User Management, update table columns (profile image + merged Name), fix actions menu labels
- ai-sales-assistant.mdx: add company profile summary to capabilities
- sms-campaigns.mdx: add image/MMS support to SMS content steps
- conversations-ai/index.mdx: add conversation summary language FAQ, fix broken web-chat setup link