### PR TITLE
docs: document visitor URL context for AI Employees on web chat (WARP…

### DIFF
--- a/docusaurus/docs/business-app/ai/ai-capabilities/creating-custom-capabilities.md
+++ b/docusaurus/docs/business-app/ai/ai-capabilities/creating-custom-capabilities.md
@@ -203,3 +203,30 @@ When creating your **Prompt**, be sure to:
 **Customer:** "Yes, that's the one."  
 *(AI calls `LookupProductDetails` with `product_id` matching BlueWave Wireless Headphones)*  
 **AI:** "Great! The *BlueWave Wireless Headphones* are priced at **$89.99**. They offer 20 hours of battery life and come with a two-year warranty."
+
+### Variation: pair the lookup with the visitor's current URL
+
+When an AI Employee is responding on **Web Chat**, it receives the URL of the page the visitor is currently on with every message. You can combine this context with a lookup capability so the AI answers vague questions ("is this still available?", "what's the price?") without needing to ask which item the visitor means.
+
+This pattern is especially powerful for businesses with structured URLs — e-commerce product pages, vehicle inventory, real estate listings, service pages, and so on.
+
+**Prompt snippet — extend the lookup capability with URL parsing:**
+
+```markdown
+## Using the Current Page URL
+Our product detail pages follow this URL pattern:
+https://www.example.com/products/[slug]/[product_id]
+
+The value at the end of the path is the `product_id`.
+
+## When to use
+- If the visitor's current URL matches the product detail pattern AND they ask a vague product question ("is this in stock", "how much", "any other colors"), parse the `product_id` from the URL and call `LookupProductDetails`.
+- Confirm the product naturally in the first line of your reply so the visitor knows you understood.
+- If the URL changes between turns, the visitor has navigated to a different product. Always use the URL from the most recent message.
+- If the visitor explicitly names a different product than the one in the URL, follow what they said and ignore the URL.
+- On non-product pages (homepage, /about, /contact), do not assume product context.
+```
+
+:::tip
+For the AI Chat Receptionist, see [Make responses page-aware with the visitor's current URL](../ai-workforce/ai-chat-receptionist/index.mdx#make-responses-page-aware-with-the-visitors-current-url) for the broader feature overview.
+:::

--- a/docusaurus/docs/business-app/ai/ai-workforce/ai-chat-receptionist/index.mdx
+++ b/docusaurus/docs/business-app/ai/ai-workforce/ai-chat-receptionist/index.mdx
@@ -513,6 +513,47 @@ To respond accurately to general inquiries, your AI Chat Receptionist needs cont
 
  For a complete guide on providing your AI Employees with Knowledge, see the [Knowledge Sources section in the AI Workforce Overview](../ai_workforce_overview.md).
 
+## Make responses page-aware with the visitor's current URL
+
+When someone chats through the Web Chat widget on your website, your AI Chat Receptionist receives the URL of the page they're on with every message they send. The AI can use that URL to answer vague, page-specific questions — "is this still available?", "what's the price?", "tell me more" — without making the visitor re-explain what they're looking at.
+
+This works automatically — no setup is required for the AI to receive the URL. To get the most out of it, make sure the relevant pages of your website are added to your AI's knowledge, and consider tuning the Role or a capability prompt to tell the AI how to interpret your URL pattern.
+
+:::info The AI sees the URL, not the page contents
+The AI is given the URL string only — it doesn't see a rendered view of the page the way you do. To answer detailed questions about what's on a page, the AI needs that page's content in its knowledge, or a [custom capability](../../ai-capabilities/creating-custom-capabilities.md) that can look up the data (for example, an inventory lookup tool keyed off the URL).
+:::
+
+### Tune a prompt to use the current URL
+
+Add instructions to your Role or to a capability prompt that explain how your URLs map to specific products, services, or pages. Here's an example for an auto dealer with structured inventory pages:
+
+```text wrap
+## Using the Current Page URL
+Our vehicle detail pages follow this URL pattern:
+https://www.example.com/inventory/[year-make-model-slug]/[id]
+
+The numeric value at the end of the path is the vehicle's id.
+
+When the customer is on a vehicle detail page:
+- If they ask anything vague — "is this still available", "what's the price", "tell me more", "any photos", "what colour is it", "is it certified" — call GetInventory using that id from the URL. Do not ask which vehicle they mean.
+- Confirm the vehicle naturally in the first line of your reply (e.g. "The 2021 Wrangler Sahara you're looking at...") so they know you understood.
+- If the URL changes between turns, the customer has navigated to a different vehicle. Always use the URL from the most recent message.
+
+When the customer is on the inventory listing page (/inventory with no id):
+- They are browsing, not viewing a specific vehicle. Ask what they're looking for if their question is vague.
+
+When the customer is on a non-inventory page (homepage, /financing, /about, contact, etc.):
+- Do not assume any vehicle context. Handle the question on its own merits.
+
+Customer words always override the URL. If they explicitly reference a different stock number, VIN, or year/make/model than what's on their current page, follow what they said and ignore the URL.
+```
+
+The same pattern works for any business with structured URLs — e-commerce product pages, service pages, real estate listings, menu items, and so on. Pair this with a [custom capability](../../ai-capabilities/creating-custom-capabilities.md) that looks up live data using the ID parsed from the URL.
+
+:::note Web Chat only
+The visitor's current URL is provided on the Web Chat channel. Other channels (SMS, voice, email, social) don't have a "current page" concept, so this context isn't available there.
+:::
+
 ## Preview your AI Chat Receptionist in action {#test-the-ai-chat-receptionists-responses}
 
 Once your AI Chat Receptionist is set up, it's important to test how it handles real conversations and monitor its interactions over time. This helps you ensure the AI is answering questions accurately, capturing leads, and creating a positive experience for your website visitors. This testing environment is also perfect for seeing how the AI Chat Receptionist behaves in a live setting.
@@ -612,5 +653,32 @@ You know your business best! To improve your AI’s accuracy, take a moment to w
 - The key information the AI should always collect from visitors
 
 Use this info to write clear Role prompts and add any relevant content to your AI’s knowledge base that might be missing.
+
+</details>
+
+<details>
+<summary>Does the AI see all of the webpage content?</summary>
+
+No. The AI is given the URL of the page the visitor is on, but it doesn't see the rendered page the way the visitor does. To answer detailed questions about what's on a page, that page's content needs to be in your AI's knowledge, or your AI needs a custom capability (like an inventory lookup) that can fetch the data using information parsed from the URL.
+
+</details>
+
+<details>
+<summary>Do I need to tune the prompt to take advantage of the current URL?</summary>
+
+It depends on what you want.
+
+- If you just want a smoother experience — the AI naturally picks up that the visitor is on a specific page and references it — no tuning is required.
+- If you want specific behavior tied to specific URL patterns (e.g. always look up inventory when the customer is on a `/inventory/[id]` page), add instructions to the Role or a capability prompt that explain the URL pattern and how the AI should react.
+
+</details>
+
+<details>
+<summary>The AI didn't seem to know about the page the visitor was on. Why?</summary>
+
+Two things to check:
+
+1. **Knowledge coverage.** The AI only knows what's in its knowledge or what a tool returns. Make sure the relevant pages of your website are added to your AI's knowledge and that the website data is up to date.
+2. **The URL itself.** The AI is given the URL string, not page contents. If the URL doesn't carry useful information (e.g. it's a generic `/page?id=abc123`), the AI may need a custom capability to translate that into something meaningful.
 
 </details>

--- a/docusaurus/docs/business-app/ai/ai-workforce/custom-ai-employees/index.md
+++ b/docusaurus/docs/business-app/ai/ai-workforce/custom-ai-employees/index.md
@@ -49,6 +49,10 @@ Every custom AI Employee follows these steps:
 
 For detailed instructions, see [How to Create Custom Capabilities](../../ai-capabilities/creating-custom-capabilities.md).
 
+:::tip Web Chat sees the visitor's current URL
+Custom AI Employees assigned to the **Web Chat** channel receive the visitor's current page URL with every message — the same as the AI Chat Receptionist. See [Make responses page-aware with the visitor's current URL](../ai-chat-receptionist/index.mdx#make-responses-page-aware-with-the-visitors-current-url) for how to tune prompts to use it.
+:::
+
 ## Available guides
 
 - [AI Data Analyst](./ai-data-analyst.md): analyze CRM data, reviews, and social engagement with structured AIR (Analyze, Interpret, Recommend) reasoning


### PR DESCRIPTION
AI Employees responding on Web Chat now receive the visitor's current page URL with every message. Add coverage on the AI Chat Receptionist page (with auto-dealer example, FAQs), a paired-lookup example on the custom capabilities page, and a one-line cross-link from custom AI Employees.