### PR TITLE
docs: add Vibe use cases index and roofing estimator playbook (draft)

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/use-cases/_category_.json
+++ b/docusaurus/docs/business-app/ai/vibe/use-cases/_category_.json
@@ -1,4 +1,8 @@
 {
   "label": "Use Cases",
-  "position": 3
+  "position": 3,
+  "link": {
+    "type": "doc",
+    "id": "business-app/ai/vibe/use-cases/index"
+  }
 }

--- a/docusaurus/docs/business-app/ai/vibe/use-cases/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/use-cases/index.md
@@ -1,0 +1,91 @@
+---
+title: "Vibe Use Cases"
+sidebar_label: "Overview"
+sidebar_position: 0
+draft: true
+description: "Practical guidance for building real tools with Vibe for your clients — what to build, how to approach it, and what to expect."
+---
+
+# Vibe Use Cases
+
+This section covers practical, real-world builds you can create for your clients using Vibe. Each use case includes the prompt used, what Vibe produced, and tips for refining the result.
+
+Before diving into individual use cases, this page covers the approach and expectations that apply across all of them.
+
+## What You Can Build for Your Clients
+
+Vibe lets you build custom tools for a client's business using plain language prompts — no coding required. Here are the types of things you can build:
+
+- **Service estimators and quote calculators** — Let their customers input details and get an instant price estimate
+- **Lead capture tools** — Collect contact information and feed it into their CRM
+- **Custom dashboards** — Pull information from different sources into one view
+- **Landing pages and websites** — Public-facing pages for their business or a specific campaign
+- **Scheduling tools** — Manage bookings, team schedules, or appointment flows
+
+## Setting Client Expectations: Think in Versions
+
+The most common mistake when starting with Vibe is trying to build something complete in one shot. Set this expectation with your clients upfront.
+
+The right approach is to think in versions. The first prompt produces a working starting point. From there, you refine with follow-up prompts, test the result, note what needs to change, and prompt again.
+
+- **The first version will not be perfect.** That's normal and expected.
+- **Each prompt should focus on one or two things.** Trying to add many features at once leads to worse results.
+- **Testing is part of building.** After each version, click through what was built and identify what to adjust next.
+
+What gets built with Vibe is also a living thing. As a client's business changes — their pricing, their services, their processes — the tool will need to be updated. Help them understand that ongoing maintenance is part of the value, not a sign that something went wrong.
+
+## Prompting Tips
+
+### Give it source material
+
+If the build involves pricing, services, or specific content, point Vibe at a real source rather than expecting it to guess.
+
+> Here is our services page: [URL]. Use the pricing from that page to build the calculator.
+
+:::note[To do before publishing]
+Clarify what database options are available for clients who need Vibe to pull from structured data rather than a URL. What formats are supported? Does the client need to set anything up first?
+:::
+
+### Use "contact intake" for CRM lead capture
+
+When you want a form to send leads to the client's CRM, use the phrase **contact intake** in your prompt. Using "contact form" may produce a form that doesn't connect to the CRM.
+
+**Use this:**
+> Add a contact intake form that captures the customer's name, email, and quote details.
+
+**Instead of:**
+> Add a contact form.
+
+### Be patient during generation
+
+Building a complex application takes time. Vibe works through the build step by step — writing files, applying design, validating the result. A detailed project can take a few minutes. If the progress indicator looks frozen, give it more time before assuming something went wrong.
+
+### Let it ask questions
+
+If a prompt involves something complex — like connecting to an external service or building a specific workflow — Vibe may ask clarifying questions before it builds. Answer those questions specifically. The more detail you provide upfront, the better the result.
+
+## Connecting to the Client's Other Tools
+
+Vibe can connect to other products and services through APIs. Some connections work out of the box with the right prompt. Others require additional setup.
+
+**What tends to work well:**
+- Lead capture that saves to the CRM (use "contact intake")
+- Pulling in content from a URL
+- Building forms with multiple fields and logic
+
+**What may require extra steps:**
+- Connecting to third-party platforms not built into the system
+- Complex multi-step workflows between different products
+- Real-time data from external databases
+
+If Vibe asks for an API endpoint or webhook URL, that's a sign the connection needs some technical setup. You can still build the front-end of the tool and connect the back-end later.
+
+## What to Expect
+
+About 90% of most projects can be built through prompting alone. The last 10% — usually specific integrations or complex logic — may need additional technical help to finish.
+
+The goal is to get as far as possible through prompting, then clearly identify what's left so the right support can be lined up for those final pieces.
+
+---
+
+*This article is based on internal testing and is being reviewed for accuracy before publication.*

--- a/docusaurus/docs/business-app/ai/vibe/use-cases/roofing-estimator.md
+++ b/docusaurus/docs/business-app/ai/vibe/use-cases/roofing-estimator.md
@@ -1,0 +1,39 @@
+---
+title: "Roofing Quote Estimator"
+sidebar_label: "Roofing Quote Estimator"
+sidebar_position: 1
+draft: true
+description: "Build a roofing quote estimator with lead capture using Vibe."
+---
+
+# Roofing Quote Estimator
+
+A service estimator is one of the strongest demonstrations of what Vibe can do for a trade or home services client. This example walks through building a quote calculator for a roofing company, complete with a lead capture form.
+
+## The Prompt
+
+> Generate a service estimator for my roofing company that calculates quotes based on roof size and materials with a lead capture form connected to my CRM.
+
+## What Vibe Built
+
+From that single prompt, Vibe produced:
+
+- A form that collects home size, number of stories, and roof pitch
+- Material selection (asphalt, architectural, premium metal, etc.)
+- An option to include or exclude tear-off of existing shingles
+- An estimated quote based on approximate material costs
+- A lead capture form to collect customer contact information
+
+## Tips for This Use Case
+
+**Use the client's actual pricing.** The default output uses general pricing approximations. For more accurate results, point Vibe at a URL from the client's website or a supplier's site that lists their real rates:
+
+> Here is our materials pricing page: [URL]. Use these prices in the estimator.
+
+**Use "contact intake" for the lead form.** To ensure the lead capture form connects to the CRM, use "contact intake" in your prompt rather than "contact form." See the [Use Cases overview](./index.md) for more on this.
+
+**Embed it on their website.** Once the estimator is built, it can be embedded on the client's existing website or deployed with a custom domain.
+
+---
+
+*This article is based on internal testing and is being reviewed for accuracy before publication.*


### PR DESCRIPTION
## Summary

- Adds a Use Cases index page for Vibe with partner-facing guidance: what to build, versioning mindset, prompting tips, and connecting to client tools
- Adds a roofing quote estimator use case as the first example
- Both files are `draft: true` — not visible in production until ready to publish
- Includes a to-do callout to clarify database options before publishing

## Test plan

- [ ] Confirm draft pages are not visible in the published site
- [ ] Review content accuracy against actual Vibe behaviour
- [ ] Resolve the database options to-do callout before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)