### PR TITLE
docs: update Vibe docs for May 6 release

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/getting-started.md
+++ b/docusaurus/docs/business-app/ai/vibe/getting-started.md
@@ -31,6 +31,8 @@ Give your project a name and an optional description, then click **Create**.
 
 ![Create a new app dialog with the App Name and Description fields filled in](./img/create-project.png)
 
+As soon as the project is created, Vibe loads the Business Profile for the selected location — name, services, hours, and contact details — into the project's knowledge base. Your prompts can draw on that information without you having to include it. See [Business Knowledge](./guides/business-knowledge.md) to learn how to add more context.
+
 ## Step 3: Write Your First Prompt
 
 After creating your project, you'll land in the Vibe editor. This is where you build your application through conversation.

--- a/docusaurus/docs/business-app/ai/vibe/guides/business-knowledge.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/business-knowledge.md
@@ -1,0 +1,41 @@
+---
+title: Business Knowledge
+sidebar_position: 7
+unlisted: true
+---
+
+# Business Knowledge
+
+Every Vibe project has a built-in knowledge base. When you create a project for a location, Vibe automatically pulls in that location's Business Profile — name, services, hours, contact information, brand voice, and FAQs — and makes it available to the AI from the first prompt.
+
+## How it works
+
+When you ask Vibe to build something that involves real business details — "build a Contact page" or "add an About section" — Vibe draws from the knowledge base to fill in accurate information instead of placeholder text. The business name, hours, services, and contact info appear correctly in the generated app without you having to supply them in the prompt.
+
+This happens automatically. There's no toggle to enable and no setup required.
+
+## Adding your own knowledge
+
+You can extend the knowledge base from the project settings page. Open **Project Settings** and find the **Knowledge** section. You can add:
+
+- **URLs** — Vibe fetches and indexes the page content
+- **Files** — Upload documents such as PDFs, specs, or brand guides
+- **Notes** — Paste in text directly: pricing tables, FAQs, product descriptions, or anything else the AI should know
+
+Everything you add goes into the same knowledge base Vibe already uses for the Business Profile. Once it's there, Vibe can reference it in any future prompt for that project.
+
+## What to add
+
+Good candidates for the knowledge base:
+
+- Pricing lists and service packages
+- Staff bios and team information
+- Brand voice guidelines or tone notes
+- FAQs you want to appear in the generated app
+- Any content the AI might otherwise get wrong or leave as placeholder text
+
+## Next Steps
+
+- [Getting Started](../getting-started.md) — Create your first project
+- [Prompting Guide](./prompting.md) — Write prompts that make the most of your business context
+- [Connectors](./connectors/index.md) — Wire your app into forms, analytics, and sign-on

--- a/docusaurus/docs/business-app/ai/vibe/guides/plan-mode.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/plan-mode.md
@@ -13,7 +13,7 @@ Every Vibe generation starts with a plan. The plan describes which files will be
 A typical run progresses through these stages, visible inline in the chat:
 
 1. **Preparing environment** — the sandbox spins up.
-2. **Thinking** — Vibe internalizes your request and works out the architecture.
+2. **Thinking** — Vibe internalizes your request, works out the architecture, and commits to a named design system — palette, typography, and UI primitives — before any code is written.
 3. **Applying theme** — the visual style you described is set.
 4. **Generating images** — any imagery the design needs is created.
 5. **Editing files** — each component, page, and configuration file appears as Vibe writes it.

--- a/docusaurus/docs/business-app/ai/vibe/guides/troubleshooting.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/troubleshooting.md
@@ -16,6 +16,7 @@ Vibe runs three layers of automatic error handling. Each layer catches a differe
 |---|---|---|
 | **Type and compile checks** | TypeScript errors, missing imports, type mismatches | Inline, while Vibe is writing or editing files |
 | **Build verification** | Errors that only show up when the project is bundled | After file changes are written, before the preview updates |
+| **Verified completion** | Remaining type errors before the run declares success | After all file edits, before the COMPLETED block appears |
 | **Runtime auto-fix** | Errors that happen in the live preview after the app loads | When the app crashes or throws while you're using it |
 
 You don't have to enable any of this. It's the default behavior on every generation.
@@ -31,6 +32,12 @@ You'll know this layer ran when Vibe sends a follow-up edit immediately after a 
 After a batch of file changes, Vibe builds the project to confirm everything compiles. If the build fails, the agent reads the error, decides whether it can fix it, and edits the offending files autonomously. The chat shows what it tried and what it fixed.
 
 You'll see status updates like "Building project," then either a success message and an updated preview, or a follow-up edit cycle that resolves the failure.
+
+### Verified completion
+
+Before the `COMPLETED` block appears, Vibe runs a final type check against the full project. If issues are found, the agent sees the errors and corrects them — up to three rounds of self-correction. If the project can't reach a clean state in three attempts, the run finishes with a **"verified with issues"** status. That's a clear signal that something needs attention, not a silent claim of success.
+
+You'll see "verified with issues" in the COMPLETED block header when this happens. Treat it the same as a build error: copy the error text and send it back as a prompt, or roll back to a clean checkpoint.
 
 ### Runtime auto-fix
 

--- a/docusaurus/docs/business-app/ai/vibe/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/index.md
@@ -47,6 +47,9 @@ Attach images to your prompts to show Vibe what you want. Use the microphone but
 ### Connectors
 Vibe wires your generated app into live platform features. The Forms connector captures submissions, the Analytics connector surfaces multi-location dashboards, and the Single sign-on connector gates a members area against your customers' existing accounts. See [Connectors](./guides/connectors/index.md).
 
+### Business Knowledge
+Every project has a built-in knowledge base pre-loaded with the location's Business Profile — name, services, hours, contact info, brand voice, and FAQs. When you ask Vibe to build a Contact page or add an About section, it fills in real details about the business instead of placeholder text. You can extend the knowledge base from the project settings page by adding URLs, files, or notes. See [Business Knowledge](./guides/business-knowledge.md).
+
 ### Image generation
 Vibe produces hosted brand-quality images on demand whenever your prompt asks for them — no setup required. See [Image generation](./guides/image-generation.md).
 
@@ -62,9 +65,9 @@ When you send a prompt, Vibe's orchestrator coordinates multiple AI agents:
 
 1. **You describe** what you want in the chat panel.
 2. **Clarification** — If the request is ambiguous, Vibe asks structured questions before continuing.
-3. **Planning** — A planning agent produces a structured plan describing the architecture, navigation, and which files will be touched.
+3. **Planning** — A planning agent produces a structured plan describing the architecture, navigation, and which files will be touched. The plan also commits to a named design system — palette, fonts, and UI primitives — before any code is written.
 4. **Generation** — A generation agent writes the code file by file, applying the theme, generating images, and editing components in real time. Type-check and build verification run continuously to catch and fix issues.
-5. **Validation** — Vibe takes a screenshot of the rendered preview and runs a build check; anything broken is auto-fixed before the run finishes.
+5. **Validation** — Vibe takes a screenshot of the rendered preview and runs a build check. Before declaring the task complete, Vibe runs a final type check and self-corrects any remaining issues — up to three rounds. If they can't be resolved, the run finishes with a "verified with issues" status instead of a silent claim of success.
 6. **Preview** — The live preview updates as soon as the build is clean.
 7. **Iteration** — You review the result and send follow-up prompts to refine it. Runtime errors in the preview trigger an auto-fix banner.
 
@@ -121,6 +124,7 @@ Vibe's chat supports multiple languages, including French, Spanish, German, Ital
 ## Next Steps
 
 - [Getting Started](./getting-started.md) — Create your first app and learn the basics
+- [Business Knowledge](./guides/business-knowledge.md) — Use real business details in your generated apps
 - [Prompting Guide](./guides/prompting.md) — Write prompts that get better results
 - [Cloning a Reference Site](./guides/clone-from-url.md) — Scaffold an app from any URL
 - [Visual Editor & Themes](./guides/visual-editor.md) — Apply themes and edit elements visually
@@ -129,4 +133,4 @@ Vibe's chat supports multiple languages, including French, Spanish, German, Ital
 - [Connectors](./guides/connectors/index.md) — Wire your app into forms, analytics, and sign-on
 - [Prompting Library](./guides/prompting-library.md) — Ready-made prompts for common use cases
 - [Troubleshooting](./guides/troubleshooting.md) — Fix common errors and unexpected behavior
-- [Use Cases](./use-cases/landing-page.md) — See real examples of what you can build with Vibe
+- [Use Cases](./use-cases/index.md) — See real examples of what you can build with Vibe


### PR DESCRIPTION
## Summary

- **Business Knowledge** — New guide covering auto-pull from Business Profile and adding custom knowledge (URLs, files, notes) via Project Settings; referenced from index and getting-started
- **Verified Completion** — Updated troubleshooting to document the 3-round self-correction loop and "verified with issues" status
- **Design system commitment** — Updated plan-mode to mention that planning now commits to a named design system before any code is written
- **Broken link fix** — `use-cases/landing-page.md` → `use-cases/index.md` (pre-existing)

## Test plan

- [ ] All internal links resolve (validated locally)
- [ ] Frontmatter valid on all files
- [ ] No unclosed tags or code blocks
- [ ] New `business-knowledge.md` appears in sidebar under Guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)