### PR TITLE
docs: update Vibe connector docs based on stakeholder session

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/guides/business-knowledge.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/business-knowledge.md
@@ -14,6 +14,20 @@ When you ask Vibe to build something that involves real business details — "bu
 
 This happens automatically. There's no toggle to enable and no setup required.
 
+### Phrases that trigger business knowledge
+
+Certain phrases reliably tell Vibe to pull from the Business Profile:
+
+- **"my business information"** — pulls contact details, hours, and location data
+- **"business profile"** — explicitly references the Business Profile record
+- **"my hours of operation"** — pulls the location's hours directly
+
+For example:
+
+> Create a contact page that shows my business information and hours of operation.
+
+Using these phrases produces more accurate results than leaving Vibe to infer that business details are needed.
+
 ## Adding your own knowledge
 
 You can extend the knowledge base from the project settings page. Open **Project Settings** and find the **Knowledge** section. You can add:

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/analytics.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/analytics.md
@@ -12,11 +12,18 @@ The Analytics connector turns your app into a multi-location dashboard. It surfa
 
 Analytics layers on the in-app metrics that Business App already aggregates for the signed-in member's businesses and locations. When the connector is enabled, Vibe routes dashboard prompts through that data layer instead of generating placeholder numbers. The numbers in the preview are live values from the platform, refreshed when the page reloads.
 
-Because the data is scoped to the signed-in member, this connector is most useful inside an area gated by [Single sign-on](./single-sign-on.md) — the panel description in Project Settings calls this out: "Surface in-app analytics for signed-in users."
+Because the data is pulled from authenticated APIs scoped to the signed-in member, the [Single sign-on](./single-sign-on.md) connector must be enabled for Analytics to work.
 
 ## Enabling the connector
 
-Open **Project Settings**, scroll to **Shared connectors**, and toggle **Analytics** on. Pair it with **Single sign-on** so the dashboard pages have a signed-in member to scope data to.
+The Analytics connector requires **Single sign-on** to be enabled. Analytics data is pulled from authenticated APIs scoped to a signed-in user — without SSO, there is no authenticated session to make those requests against.
+
+To set up both:
+1. Open **Project Settings** and scroll to **Shared connectors**.
+2. Toggle **Single sign-on** on first.
+3. Toggle **Analytics** on.
+
+With both enabled, your dashboard prompts are wired to live data scoped to the signed-in member.
 
 ## When to use it
 
@@ -27,15 +34,21 @@ Reach for Analytics when:
 - You want a trend view (last 30 days, last quarter) of a key metric.
 - You want a member-facing summary, like a loyalty status page or an account-activity panel.
 
-## Asking for an analytics dashboard
+## Be specific about what you want to see
 
-Describe the metrics and the cuts you want:
+The Analytics connector has access to a large range of metrics. Vague requests like "show me my data" are harder to act on than specific ones. Describe the exact metric, the time range, and how you want it grouped or visualized.
+
+**Good:**
+> Add a reviews widget to the dashboard showing the last 90 days of reviews and a count of reviews grouped by star rating.
 
 > Build an owner dashboard showing service requests per location for the last 30 days, top three services this month, and a bar chart of weekly revenue.
 
 > Add a metrics page with three tiles: total leads this week, average response time, and conversion rate.
 
 > Show a multi-location comparison: one row per location, columns for monthly visits, bookings, and average ticket size.
+
+**Less effective:**
+> Show me my analytics.
 
 When your prompt mentions metrics, dashboards, or per-location cuts, Vibe's supervisor agent recognizes the intent and routes the request through the Analytics connector. The generated dashboard is wired to live data — refresh the preview and the numbers update.
 

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/forms.mdx
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/forms.mdx
@@ -41,15 +41,23 @@ Reach for Forms when you want any of the following in your generated app:
 
 ## Building an app with a form
 
-Describe the form you want as part of any prompt:
+Describe the form you want as part of any prompt. By default, Vibe creates a contact form that captures information about a person (name, email, phone, and similar contact details).
 
-> Add a contact form at the bottom of the landing page. Collect name, email, and message.
+> Add a contact form at the bottom of the landing page. Collect first name, last name, email, and phone number.
 
 > Create a lead capture popup that asks for name, email, and company size.
 
 > Add a "Book an appointment" form to the services page with fields for name, phone, preferred service, and preferred date.
 
 Vibe renders a form styled to match your application's theme. Submissions are captured by Business App's Forms backend automatically, so you don't have to wire up a backend yourself.
+
+### Using an existing form
+
+If you already have a form set up in Business App, you can tell Vibe to embed it instead of creating a new one:
+
+> Use the existing inquiry form on the contact page instead of creating a new one.
+
+Vibe will look up the available forms and wire the matching one into the page.
 
 ## Editing a form
 

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
@@ -14,6 +14,8 @@ Single sign-on layers on Business App's customer authentication. When you enable
 
 The OAuth client ID for the project is shown in the **Overview** card on the Project Settings page once the connector is enabled.
 
+**Who can sign in:** Any user who already has access to your Business App account can sign in to your Vibe-built app. This connector is not intended for signing in your business's end customers or website visitors — it's for members of your Business App account (owners, staff, managers). There are no per-user access controls within that group at this time; if someone has Business App access for the account, they can sign in.
+
 ## Enabling the connector
 
 Open **Project Settings**, scroll to **Shared connectors**, and toggle **Single sign-on** on. Toggling it on provisions the OAuth client automatically — there's nothing you need to configure manually for the redirect flow to start working in your generated app.

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
@@ -16,6 +16,10 @@ The OAuth client ID for the project is shown in the **Overview** card on the Pro
 
 **Who can sign in:** Any user who already has access to your Business App account can sign in to your Vibe-built app. This connector is not intended for signing in your business's end customers or website visitors — it's for members of your Business App account (owners, staff, managers). There are no per-user access controls within that group at this time; if someone has Business App access for the account, they can sign in.
 
+:::caution Work in progress
+Access controls for sign-in are still being developed. More granular controls are coming in a future update.
+:::
+
 ## Enabling the connector
 
 Open **Project Settings**, scroll to **Shared connectors**, and toggle **Single sign-on** on. Toggling it on provisions the OAuth client automatically — there's nothing you need to configure manually for the redirect flow to start working in your generated app.


### PR DESCRIPTION
## Summary

Updates to the Vibe connector docs based on a May 13 stakeholder session with Jesse.

- **Analytics** — SSO is now documented as a hard requirement (not just a recommendation); added specificity guidance with good/less effective prompt examples; added reviews/star-rating example prompt
- **Forms** — clarified that Vibe creates contact forms by default; added a "Using an existing form" section with example prompt language
- **Single sign-on** — clarified that only Business App account users can sign in (not external customers of the SMB)
- **Business Knowledge** — added specific trigger phrases ("my business information", "business profile") that reliably pull from the Business Profile

## Test plan

- [ ] Verify all four updated pages render correctly
- [ ] Confirm Analytics page clearly communicates SSO requirement
- [ ] Check Forms page example prompts are accurate to current UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)