### PR TITLE
fix: correct forms connector links resolving to .md instead of .mdx

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/index.md
@@ -11,7 +11,7 @@ Connectors let your Vibe-built app do real work, not just look like it could. Ea
 There are three connectors today:
 
 - [Single sign-on](./single-sign-on.md) — let your customers sign in with their existing account.
-- [Forms](./forms.md) — capture form submissions from your app.
+- [Forms](./forms) — capture form submissions from your app.
 - [Analytics](./analytics.md) — surface in-app metrics for signed-in users.
 
 ## Enabling a connector
@@ -34,7 +34,7 @@ That single prompt activates Forms (contact), Single sign-on (members area), and
 
 ## Next Steps
 
-- [Forms](./forms.md) — Capture contact form and lead submissions from your app
+- [Forms](./forms) — Capture contact form and lead submissions from your app
 - [Single sign-on](./single-sign-on.md) — Gate a members area with existing customer accounts
 - [Analytics](./analytics.md) — Surface multi-location metrics for signed-in users
 - [Prompting Library](../prompting-library.md) — Ready-made prompts for each connector

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
@@ -52,7 +52,7 @@ The supervisor agent recognizes phrases like "sign in", "members area", "gated",
 - A session-aware layout that knows when a member is signed in and exposes their identity to the rest of the app.
 - A sign-out control wired to the same flow so members can end their session cleanly.
 
-Single sign-on pairs naturally with the [Analytics connector](./analytics.md) for member-specific data, and with the [Forms connector](./forms.md) when a form should be visible only to signed-in members.
+Single sign-on pairs naturally with the [Analytics connector](./analytics.md) for member-specific data, and with the [Forms connector](./forms) when a form should be visible only to signed-in members.
 
 ## Next Steps
 

--- a/docusaurus/docs/business-app/ai/vibe/guides/prompting-library.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/prompting-library.md
@@ -25,7 +25,7 @@ What to expect: a single-page site with the seven sections in order, themed in s
 
 > Create a website for a dental clinic called "Bright Smile Dental." Include a home page with services, a team page with dentist bios and photos, an FAQ page with common questions, and a booking page with a contact form.
 
-What to expect: four pages with shared navigation, a generated team-photo placeholder set, and a contact form that activates the [Forms connector](./connectors/forms.md).
+What to expect: four pages with shared navigation, a generated team-photo placeholder set, and a contact form that activates the [Forms connector](./connectors/forms).
 
 ### Service business with multi-location
 
@@ -103,7 +103,7 @@ What to expect: the reference site's structure and visual style, with your busin
 
 > Add a contact form at the bottom of the landing page. Collect name, email, and message. Style it to match the rest of the page.
 
-What to expect: a form rendered in your theme, wired through the [Forms connector](./connectors/forms.md) so submissions are captured automatically.
+What to expect: a form rendered in your theme, wired through the [Forms connector](./connectors/forms) so submissions are captured automatically.
 
 ### Lead capture popup
 


### PR DESCRIPTION
## Summary

- Fixed 5 internal links pointing to `forms.md` — the file is `forms.mdx`, causing Docusaurus to resolve to the wrong URL (`/forms.md` instead of `/forms/`)
- Affected files: `connectors/index.md`, `connectors/single-sign-on.md`, `guides/prompting-library.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)