### PR TITLE
docs: add walkthrough videos to AI Data Analyst and Support Employee guides

### DIFF
--- a/docusaurus/docs/business-app/ai/ai-workforce/ai_workforce_overview.md
+++ b/docusaurus/docs/business-app/ai/ai-workforce/ai_workforce_overview.md
@@ -93,9 +93,9 @@ Pre-configured AI Employees (Chat Receptionist, Voice Receptionist) come ready t
 
 Build a custom AI Employee when you need a role that isn't covered by a pre-configured option, such as:
 
-- **[AI Data Analyst](./custom-ai-employees/ai-data-analyst.md)** — analyzes CRM, review, and social data to deliver structured insights
+- **[AI Data Analyst](./custom-ai-employees/ai-data-analyst.mdx)** — analyzes CRM, review, and social data to deliver structured insights
 - **[Inside Sales Representative](./custom-ai-employees/inside-sales-representative.md)** — qualifies inbound leads before capturing contact information or booking appointments
-- **[AI Support Employee](./custom-ai-employees/ai-support-employee.md)** — resolves customer inquiries via chat and SMS, and escalates when a question falls outside the knowledge base
+- **[AI Support Employee](./custom-ai-employees/ai-support-employee.mdx)** — resolves customer inquiries via chat and SMS, and escalates when a question falls outside the knowledge base
 
 See [Custom AI Employees](./custom-ai-employees/index.md) for the full setup process and additional examples.
 

--- a/docusaurus/docs/business-app/ai/ai-workforce/custom-ai-employees/ai-data-analyst.mdx
+++ b/docusaurus/docs/business-app/ai/ai-workforce/custom-ai-employees/ai-data-analyst.mdx
@@ -17,6 +17,30 @@ keywords:
 
 The AI Data Analyst is a custom AI Employee that helps you make data-backed decisions by analyzing CRM data, customer reviews, NPS feedback, and social engagement metrics. It is designed for internal use: you chat with it directly inside Business App to get structured insights on your business data. It uses a structured reasoning framework called AIR (Analyze, Interpret, Recommend) to deliver clear insights and actionable next steps instead of raw data dumps.
 
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/fuoold4f5g?web_component=true&seo=true"
+      title="AI Data Analyst walkthrough"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
+
 ## Why build an AI Data Analyst?
 
 Business data lives in multiple places: CRM records, customer reviews, NPS surveys, and social media. Without a dedicated analyst, you often face:

--- a/docusaurus/docs/business-app/ai/ai-workforce/custom-ai-employees/ai-support-employee.mdx
+++ b/docusaurus/docs/business-app/ai/ai-workforce/custom-ai-employees/ai-support-employee.mdx
@@ -19,6 +19,30 @@ keywords:
 
 The AI Support Employee is a custom AI Employee that handles inbound customer inquiries with an empathetic, resolution-first approach. It answers questions immediately using your knowledge base, follows a structured support framework for complaints and troubleshooting, and captures contact details for follow-up when a question falls outside what it can answer. It is designed for SMS and chat channels, where brevity and warmth matter more than formatted responses.
 
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/sucs5cue6a?web_component=true&seo=true"
+      title="AI Support Employee walkthrough"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
+
 ## Why build an AI Support Employee?
 
 Customers reaching out via chat expect fast, helpful responses: not hold queues or form submissions. Without an AI handling first-contact support, businesses face:

--- a/docusaurus/docs/business-app/ai/ai-workforce/custom-ai-employees/index.md
+++ b/docusaurus/docs/business-app/ai/ai-workforce/custom-ai-employees/index.md
@@ -31,9 +31,9 @@ Custom AI Employees are specialized digital team members you build from scratch 
 
 Build a custom AI Employee when you want to expand your workforce with a specialized role not covered by a pre-configured option, such as:
 
-- An **[AI Data Analyst](./ai-data-analyst.md)** that reasons through CRM, review, and social data to deliver structured insights
+- An **[AI Data Analyst](./ai-data-analyst.mdx)** that reasons through CRM, review, and social data to deliver structured insights
 - An **[Inside Sales Representative](./inside-sales-representative.md)** that qualifies inbound leads before capturing contact information or booking appointments
-- An **[AI Support Employee](./ai-support-employee.md)** that resolves customer inquiries via chat and SMS, and escalates with structured message capture when a question falls outside the knowledge base
+- An **[AI Support Employee](./ai-support-employee.mdx)** that resolves customer inquiries via chat and SMS, and escalates with structured message capture when a question falls outside the knowledge base
 - A **compliance assistant** that checks processes against internal policies
 - Any role where the default AI Employees don't match your workflow
 
@@ -55,6 +55,6 @@ Custom AI Employees assigned to the **Web Chat** channel receive the visitor's c
 
 ## Available guides
 
-- [AI Data Analyst](./ai-data-analyst.md): analyze CRM data, reviews, and social engagement with structured AIR (Analyze, Interpret, Recommend) reasoning
+- [AI Data Analyst](./ai-data-analyst.mdx): analyze CRM data, reviews, and social engagement with structured AIR (Analyze, Interpret, Recommend) reasoning
 - [Inside Sales Representative](./inside-sales-representative.md): qualify inbound leads, capture contact information, and book appointments with a sales-first conversational approach
-- [AI Support Employee](./ai-support-employee.md): resolve customer support inquiries via chat and SMS, with structured empathy for complaints and automatic escalation when questions fall outside the knowledge base
+- [AI Support Employee](./ai-support-employee.mdx): resolve customer support inquiries via chat and SMS, with structured empathy for complaints and automatic escalation when questions fall outside the knowledge base


### PR DESCRIPTION
## Summary

- Embed standard responsive Wistia players on the **AI Data Analyst** and **AI Support Employee** custom employee guides immediately after each intro paragraph.
- Convert both articles from `.md` to `.mdx` so the embed JSX matches repo conventions, and refresh links from the Workforce overview and Custom AI Employees index.