### PR TITLE
docs: remove branching reference from campaigns index

### DIFF
--- a/docusaurus/docs/business-app/campaigns/index.mdx
+++ b/docusaurus/docs/business-app/campaigns/index.mdx
@@ -47,7 +47,7 @@ Campaigns help you send the right message to the right people at the right time.
 ## What you can do
 
 - Build emails in a visual editor using templates and content blocks
-- Create multi‑step campaigns with delays and branching
+- Create multi‑step campaigns with delays
 - Send to specific contacts and lists associated with your companies
 - Pause, resume, or edit campaigns before publishing
 - Preview and test campaigns as a specific account


### PR DESCRIPTION
## Summary
- Removed reference to "branching" in the Campaigns overview page, as the branching feature does not exist

## Test plan
- [ ] Verify the bullet on the Campaigns page reads correctly without the branching reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)