### PR TITLE
docs: update Vibe docs from May 20 stakeholder transcript

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/analytics.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/analytics.md
@@ -10,7 +10,9 @@ The Analytics connector turns your app into a multi-location dashboard. It surfa
 
 ## What it layers on
 
-Analytics layers on the in-app metrics that Business App already aggregates for the signed-in member's businesses and locations. When the connector is enabled, Vibe routes dashboard prompts through that data layer instead of generating placeholder numbers. The numbers in the preview are live values from the platform, refreshed when the page reloads.
+Analytics layers on the in-app metrics that Business App already aggregates for the signed-in member's businesses and locations. The metrics available are the same ones that appear across Business App's products — reviews, listings, reputation, social, and more. Think of them as all the stat cards you see throughout the platform, including everything that surfaces in the Executive Report.
+
+When the connector is enabled, Vibe routes dashboard prompts through that data layer instead of generating placeholder numbers. You describe what you want to see in plain language; Vibe identifies the right metric and builds the query automatically. The numbers in the preview are live values from the platform, refreshed when the page reloads.
 
 Because the data is pulled from authenticated APIs scoped to the signed-in member, the [Single sign-on](./single-sign-on.md) connector must be enabled for Analytics to work.
 

--- a/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/connectors/single-sign-on.md
@@ -54,6 +54,17 @@ The supervisor agent recognizes phrases like "sign in", "members area", "gated",
 
 Single sign-on pairs naturally with the [Analytics connector](./analytics.md) for member-specific data, and with the [Forms connector](./forms) when a form should be visible only to signed-in members.
 
+## Iframe limitation
+
+Single sign-on does not work when your Vibe app is embedded inside an iframe. Browser sandboxing prevents the OAuth redirect flow from completing inside an embedded frame.
+
+If your app will be displayed inside an iframe, use one of these approaches:
+
+- **Open in a new tab** — add a sign-in button that opens the full app URL in a new tab so the OAuth flow can complete outside the iframe.
+- **Pop-up sign-in** — prompt Vibe to implement sign-in as a pop-up window rather than a redirect. Pop-ups are not subject to the same iframe sandboxing restrictions.
+
+If your app is standalone (not embedded in another page), this limitation does not apply.
+
 ## Next Steps
 
 - [Connectors](./index.md) — Overview of all connectors and how to combine them

--- a/docusaurus/docs/business-app/ai/vibe/guides/custom-domain.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/custom-domain.md
@@ -6,9 +6,15 @@ unlisted: true
 
 # Custom Domains
 
-On the Professional plan, you can publish your Vibe app to a domain you own. After you add a domain, Vibe automatically provisions an SSL certificate once your DNS records are verified.
+Every Vibe project gets a default published URL automatically. On the Professional plan, you can also publish to a domain you own. TLS is provisioned automatically for both your default URL and any custom domain — you don't need to purchase or manage certificates.
 
-## Requirements
+## Your default domain
+
+Every project includes a default URL that's ready as soon as you publish. You can view and edit this URL in the **Publish** section of your project. No DNS setup is required — it's provisioned and secured automatically.
+
+Visiting the bare domain (without `www`) redirects to the full URL automatically.
+
+## Requirements for custom domains
 
 Custom domains require the Professional plan. If you're on a different plan, upgrade first through the self-checkout flow in Business App. See [Credits](../credits.md) for information on plan upgrades.
 


### PR DESCRIPTION
## Summary

- Add SSO iframe limitation section with open-in-new-tab and pop-up sign-in workarounds
- Clarify that Analytics connector data draws from the same metrics as Business App's Executive Report
- Add default domain section to custom-domain doc; note TLS is automatic for all domains (no cert purchasing needed)

## Test plan

- [ ] Review SSO iframe limitation section for accuracy and tone
- [ ] Review Analytics "What it layers on" update for clarity
- [ ] Review custom-domain default domain section

🤖 Generated with [Claude Code](https://claude.com/claude-code)