### PR TITLE
fix: repair broken use-cases category link causing build failure

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/use-cases/_category_.json
+++ b/docusaurus/docs/business-app/ai/vibe/use-cases/_category_.json
@@ -2,7 +2,6 @@
   "label": "Use Cases",
   "position": 3,
   "link": {
-    "type": "doc",
-    "id": "business-app/ai/vibe/use-cases/index"
+    "type": "generated-index"
   }
 }


### PR DESCRIPTION
## Summary

- Fixes a broken `_category_.json` in `business-app/ai/vibe/use-cases/` that referenced a non-existent `index` doc, causing the Cloud Build to fail after PR #452 was merged
- Changed `"type": "doc"` to `"type": "generated-index"` so Docusaurus auto-generates the category page

## Test plan

- [ ] Confirm Cloud Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)