### PR TITLE
fix: repair broken integrations.md links in landing-page use case

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/use-cases/landing-page.mdx
+++ b/docusaurus/docs/business-app/ai/vibe/use-cases/landing-page.mdx
@@ -28,7 +28,7 @@ In **Shared connectors**, toggle **Forms** on. The badge changes to **Enabled**.
 
 <img src={require('./img/vibe-connectors.png').default} alt="Shared connectors panel with Forms toggled on and labeled Enabled" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-For more on connectors, see [Integrations](../guides/integrations.md).
+For more on connectors, see [Connectors](../guides/connectors/index.md).
 
 ## Step 2: Write the starting prompt
 
@@ -98,7 +98,7 @@ This example shows how much a single well-formed prompt can produce. To polish o
 Common next steps for a landing page:
 
 1. Apply a theme in Design mode to match the brand. See [Visual Editor & Themes](../guides/visual-editor.md).
-2. Replace placeholder images with AI-generated ones, for example: "Regenerate the hero image with a 16:9 aspect ratio and warmer lighting." See [Integrations](../guides/integrations.md#image-generation).
+2. Replace placeholder images with AI-generated ones, for example: "Regenerate the hero image with a 16:9 aspect ratio and warmer lighting." See [Image Generation](../guides/image-generation.md).
 3. Tune the contact form: "Add a phone number field to the contact form" or "Show a thank-you message after submission."
 4. Add targeted sections through prompts: "Add a testimonials section before the footer with three customer quotes."
 5. Use the Visual Editor for small adjustments such as padding, font size, or icon swaps.
@@ -122,5 +122,6 @@ Pair this example with these guides as you build:
 - [Prompting Guide](../guides/prompting.md): write prompts that produce strong first results
 - [Plan Mode](../guides/plan-mode.md): review and approve Vibe's implementation plan before code is generated
 - [Visual Editor & Themes](../guides/visual-editor.md): branding and element-level edits
-- [Integrations](../guides/integrations.md): Forms and image generation
+- [Connectors](../guides/connectors/index.md): Forms connector setup
+- [Image Generation](../guides/image-generation.md): generating and replacing images
 - [Troubleshooting](../guides/troubleshooting.md): recover from errors and stuck generations


### PR DESCRIPTION
Replaced three references to the non-existent guides/integrations.md with the correct paths: connectors/index.md and image-generation.md.