### PR TITLE
fix: remove duplicate description key in Vibe Use Cases index

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/use-cases/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/use-cases/index.md
@@ -4,7 +4,6 @@ sidebar_label: "Overview"
 sidebar_position: 0
 draft: false
 description: "Practical guidance for building real tools with Vibe for your clients — what to build, how to approach it, and what to expect."
-description: "Practical guidance for building real tools with Vibe — what to build, how to approach it, and what to expect."
 ---
 
 # Vibe Use Cases


### PR DESCRIPTION
Duplicate frontmatter key caused YAML parse failure and broke the Cloud Build.