### PR TITLE
DOC-598: Update project settings instructions in Vibe guides

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/guides/business-knowledge.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/business-knowledge.md
@@ -6,11 +6,11 @@ unlisted: false
 
 # Business Knowledge
 
-Every Vibe project has a built-in knowledge base. When you create a project for a location, Vibe automatically pulls in that location's Business Profile — name, services, hours, contact information, brand voice, and FAQs — and makes it available to the AI from the first prompt.
+Every Vibe project has a built-in knowledge base. When you create a project for a location, Vibe automatically pulls in that location's Business Profile ? name, services, hours, contact information, brand voice, and FAQs ? and makes it available to the AI from the first prompt.
 
 ## How it works
 
-When you ask Vibe to build something that involves real business details — "build a Contact page" or "add an About section" — Vibe draws from the knowledge base to fill in accurate information instead of placeholder text. The business name, hours, services, and contact info appear correctly in the generated app without you having to supply them in the prompt.
+When you ask Vibe to build something that involves real business details ? "build a Contact page" or "add an About section" ? Vibe draws from the knowledge base to fill in accurate information instead of placeholder text. The business name, hours, services, and contact info appear correctly in the generated app without you having to supply them in the prompt.
 
 This happens automatically. There's no toggle to enable and no setup required.
 
@@ -18,9 +18,9 @@ This happens automatically. There's no toggle to enable and no setup required.
 
 Certain phrases reliably tell Vibe to pull from the Business Profile:
 
-- **"my business information"** — pulls contact details, hours, and location data
-- **"business profile"** — explicitly references the Business Profile record
-- **"my hours of operation"** — pulls the location's hours directly
+- **"my business information"** ? pulls contact details, hours, and location data
+- **"business profile"** ? explicitly references the Business Profile record
+- **"my hours of operation"** ? pulls the location's hours directly
 
 For example:
 
@@ -30,11 +30,11 @@ Using these phrases produces more accurate results than leaving Vibe to infer th
 
 ## Adding your own knowledge
 
-You can extend the knowledge base from the project settings page. Open **Project Settings** and find the **Knowledge** section. You can add:
+You can extend the knowledge base from the project settings page. Click the 'Configure' button for the project to open the Project setting page and find the **Knowledge** section. You can add:
 
-- **URLs** — Vibe fetches and indexes the page content
-- **Files** — Upload documents such as PDFs, specs, or brand guides
-- **Notes** — Paste in text directly: pricing tables, FAQs, product descriptions, or anything else the AI should know
+- **URLs** ? Vibe fetches and indexes the page content
+- **Files** ? Upload documents such as PDFs, specs, or brand guides
+- **Notes** ? Paste in text directly: pricing tables, FAQs, product descriptions, or anything else the AI should know
 
 Everything you add goes into the same knowledge base Vibe already uses for the Business Profile. Once it's there, Vibe can reference it in any future prompt for that project.
 
@@ -50,6 +50,6 @@ Good candidates for the knowledge base:
 
 ## Next Steps
 
-- [Getting Started](../getting-started.md) — Create your first project
-- [Prompting Guide](./prompting.md) — Write prompts that make the most of your business context
-- [Connectors](./connectors/index.md) — Wire your app into forms, analytics, and sign-on
+- [Getting Started](../getting-started.md) ? Create your first project
+- [Prompting Guide](./prompting.md) ? Write prompts that make the most of your business context
+- [Connectors](./connectors/index.md) ? Wire your app into forms, analytics, and sign-on


### PR DESCRIPTION
Updates the mentions of "Open Project Settings" to "Click the 'Configure' button for the project to open the Project setting page" in the Vibe Business Knowledge guide as requested in DOC-598.