### PR TITLE
Remove draft tags from dashboard use case and custom domain

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/guides/custom-domain.mdx
+++ b/docusaurus/docs/business-app/ai/vibe/guides/custom-domain.mdx
@@ -1,7 +1,6 @@
 ---
 title: Custom Domains
 sidebar_position: 4
-unlisted: false
 ---
 
 # Custom Domains

--- a/docusaurus/docs/business-app/ai/vibe/use-cases/analytics-dashboard.mdx
+++ b/docusaurus/docs/business-app/ai/vibe/use-cases/analytics-dashboard.mdx
@@ -2,7 +2,6 @@
 title: "Analytics Dashboard with SSO"
 sidebar_label: "Analytics Dashboard with SSO"
 sidebar_position: 4
-draft: true
 description: "Build a sign-in-protected analytics dashboard showing real business data using Vibe."
 ---
 


### PR DESCRIPTION
The The analytics-dashboard.mdx file was save as a draft and didn't show in the side bar. Removed the tag from front matter.
The custom domain article under vibe guides had an unnecessary unlisted=false tag which I removed. 