### PR TITLE
docs: update Vibe credits and Project Settings navigation

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/credits.md
+++ b/docusaurus/docs/business-app/ai/vibe/credits.md
@@ -10,7 +10,7 @@ Vibe uses credits to measure AI activity. Your subscription includes a credit al
 
 ## How Credits Work
 
-Activity in Vibe — generating applications, editing pages, and running builds — consumes credits. Each Vibe subscription includes a monthly credit allowance that resets each billing period.
+Activity in Vibe — generating applications, editing pages, and running builds — consumes credits. Each Vibe subscription includes a credit allowance that resets each billing period.
 
 The amount of credits an action uses depends on its size:
 
@@ -25,20 +25,51 @@ Your remaining credit balance is visible in the chat input area and on each proj
 
 When your included credits are used up, Vibe opens an Upgrade dialog where you can complete checkout directly in Business App — no support ticket or wait time required.
 
-<!-- screenshot needed: Upgrade dialog when credits run out -->
-
 ## Credit Allowances by Plan
 
-<!-- TODO: Verify plan credit allowances and credit pack costs before publishing. 
-     Transcript said 250/month but UI showed 100/month — confirm with Jesse which is correct.
-     Also confirm credit pack pricing (100/month and 200/month add-ons shown in screenshot). -->
+| Plan | Credits | Projects & published apps |
+|------|---------|--------------------------|
+| Free | 250/day, refreshed daily | Up to 1 |
+| Standard ($19/mo) | 10,000/month | Up to 5 |
+| Pro ($49/mo) | 25,000/month | Unlimited |
 
-| Plan | Monthly credits |
-|------|----------------|
-| Professional | 100 |
+### Free
 
-## Purchasing More Credits
+Ideal for exploring Vibe and shipping your first app.
 
-You can buy additional credit packs directly in Business App through the self-checkout flow. From the same flow, you can upgrade your subscription to the Professional plan, which includes a higher credit allowance and unlocks additional features like [custom domains](./guides/custom-domain.mdx).
+**Features included:**
+- Chat, voice prompting, plan mode, site cloning, and visual editor
+- Business knowledge integration
+- Native CRM lead-form connector
+- Image generation and uploads
+- Auto checkpoints and live error recovery
+
+### Standard ($19/mo)
+
+Ideal for shipping apps with full business context. Includes all Free features, plus:
+
+- Custom domain support
+- Analytics and SSO connectors
+- White-label support (platform badge removed from your published app)
+
+### Pro ($49/mo)
+
+Ideal for building professional apps with the full feature set. Includes all Standard features, plus:
+
+- Download project (.zip)
+- Supabase connector
+
+## Add-On Credits
+
+Add-on credit packs are ideal for expanding and sustaining large-scale builds. You can purchase them at any time from within Business App.
+
+| Pack size | Price |
+|-----------|-------|
+| 10,000 credits | $19 |
+| 25,000 credits | $47.50 |
+| 50,000 credits | $95 |
+| 100,000 credits | $190 |
+
+Unused add-on credits carry over into the next month as long as your add-on remains active.
 
 ![Vibe Professional upgrade modal showing credit pack options](./img/buy-more-credits.webp)

--- a/docusaurus/docs/business-app/ai/vibe/guides/business-knowledge.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/business-knowledge.md
@@ -30,7 +30,7 @@ Using these phrases produces more accurate results than leaving Vibe to infer th
 
 ## Adding your own knowledge
 
-You can extend the knowledge base from the project settings page. Open **Project Settings** and find the **Knowledge** section. You can add:
+You can extend the knowledge base from the Project Settings page. Click **Configure** for the project to open the Project Settings page, then find the **Knowledge** section. You can add:
 
 - **URLs** — Vibe fetches and indexes the page content
 - **Files** — Upload documents such as PDFs, specs, or brand guides

--- a/docusaurus/docs/business-app/ai/vibe/use-cases/roofing-estimator.mdx
+++ b/docusaurus/docs/business-app/ai/vibe/use-cases/roofing-estimator.mdx
@@ -70,7 +70,7 @@ From that single prompt, Vibe produced:
 
 ## Tips for this use case
 
-**Add real material and labour costs to Business Knowledge.** The default output uses general pricing approximations. For more accurate estimates, go to **Project Settings → Knowledge** and add a Note with the client's actual material and labour rates. Once it's there, prompt Vibe to use it:
+**Add real material and labour costs to Business Knowledge.** The default output uses general pricing approximations. For more accurate estimates, click **Configure** for the project to open the Project Settings page, go to the **Knowledge** section, and add a Note with the client's actual material and labour rates. Once it's there, prompt Vibe to use it:
 
 > Update the estimator to use the pricing from my Business Knowledge instead of the default approximations.
 


### PR DESCRIPTION
## Summary

- Updated Vibe credits article with current Free, Standard ($19/mo), and Pro ($49/mo) plan tiers, credit allowances, feature lists, and add-on credit pack pricing
- Updated "Open Project Settings" wording in `business-knowledge.md` and `roofing-estimator.mdx` to reference the Configure button

## Test plan

- [ ] Review credits article for accuracy against current plan tiers
- [ ] Confirm navigation wording matches the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)