### PR TITLE
docs: update Vibe credits cost values

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/credits.md
+++ b/docusaurus/docs/business-app/ai/vibe/credits.md
@@ -16,8 +16,8 @@ The amount of credits an action uses depends on its size:
 
 | Action | Credit cost |
 |--------|-------------|
-| Large edit or full site generation | ~5 credits |
-| Small edit | 0.5–1 credit |
+| Large edit or full site generation | ~500 credits |
+| Small edit | 50–100 credits |
 
 Credits are tied to the account they were issued to and cannot be transferred to other accounts.
 


### PR DESCRIPTION
## Summary

- Updates credit cost values in the Vibe Credits article to reflect current pricing
- Large edit / full site generation: ~5 → ~500 credits
- Small edit: 0.5–1 → 50–100 credits

## Test plan

- [ ] Confirm updated credit values are accurate
- [ ] Confirm no formatting issues on the Credits page

🤖 Generated with [Claude Code](https://claude.com/claude-code)