### PR TITLE
docs: update Vibe credits — expand how it works with example prompts

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/credits.md
+++ b/docusaurus/docs/business-app/ai/vibe/credits.md
@@ -10,14 +10,14 @@ Vibe uses credits to measure AI activity. Your subscription includes a credit al
 
 ## How Credits Work
 
-Activity in Vibe — generating applications, editing pages, and running builds — consumes credits. Each Vibe subscription includes a credit allowance that resets each billing period.
+A credit is used each time you send a message to Vibe. How many credits a message costs depends on the complexity of the task. Each Vibe subscription includes a credit allowance that resets each billing period.
 
-The amount of credits an action uses depends on its size:
-
-| Action | Credit cost |
-|--------|-------------|
-| Large edit or full site generation | ~500 credits |
-| Small edit | 50–100 credits |
+| Action | Example prompt | Credits |
+|--------|---------------|---------|
+| Style or copy edits | "Change the colour theme to blue" | ~150 |
+| Insert a snippet | "Add AI Receptionist web chat widget with the script on the page" | ~100 |
+| Generate a new component | "Add a contact form and connected to my CRM" | ~300 |
+| Build a multi-page website | "Create a 4-page business website with my business profile" | ~500 |
 
 Credits are tied to the account they were issued to and cannot be transferred to other accounts.
 


### PR DESCRIPTION
## Summary

- Rewrites the intro line under "How Credits Work" to match in-product language: "A credit is used each time you send a message to Vibe."
- Replaces the 2-row cost table with a more detailed 4-row table including example prompts and credit estimates (style edits ~150, snippets ~100, new component ~300, multi-page site ~500)

## Test plan

- [ ] Confirm updated table renders correctly on the Credits page
- [ ] Confirm example prompts and credit values are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)