### PR TITLE
docs: document multi-form embed and host-page ::part() CSS styling

### DIFF
--- a/docusaurus/docs/business-app/crm/forms/form-builder.md
+++ b/docusaurus/docs/business-app/crm/forms/form-builder.md
@@ -95,6 +95,93 @@ Copy the embed code and place it on your website landing page or contact page. I
 
 ![](../img/embed.png)
 
+### Embed multiple forms on the same page
+
+You can place more than one form on a single page. Each form has its own embed code — duplicate the `<script>` tag for each form and change only the `data=` attribute:
+
+```html
+<!-- First form -->
+<script
+  async
+  data-crm-form-widget
+  src="https://www.cdnlinks.vendasta.com/.../custom_form.widget.js"
+  data="YOUR_BASE64_DATA_FORM_1"
+></script>
+
+<!-- Second form -->
+<script
+  async
+  data-crm-form-widget
+  src="https://www.cdnlinks.vendasta.com/.../custom_form.widget.js"
+  data="YOUR_BASE64_DATA_FORM_2"
+></script>
+```
+
+Copy the embed code from each form's **Embed** tab — the `data=` value is the only thing that differs between forms.
+
 ## Step 5: Test your form
 
 Submit a test response to confirm that a contact is captured in the CRM and any automations run as expected.
+
+## Style a form from your website's stylesheet
+
+The **Custom CSS** editor inside the Design tab styles the form from within — standard CSS selectors like `input` or `.submit-button` work there. If you want to apply styles from your *website's own stylesheet* instead, you need a different approach.
+
+Each form renders in an isolated container that blocks outside CSS from reaching its internal elements. To style across that boundary, use the CSS `::part()` pseudo-element:
+
+```css
+/* Target all inputs across every embedded form */
+.crm-form-host::part(input) {
+  border: 2px solid #3b82f6;
+  border-radius: 6px;
+}
+
+/* Target labels */
+.crm-form-host::part(label) {
+  font-weight: 600;
+}
+
+/* Target the submit button */
+.crm-form-host::part(submit-button) {
+  background-color: #2563eb;
+  color: white;
+  border-radius: 999px;
+}
+```
+
+### Available part names
+
+| Part name | What it targets |
+|-----------|----------------|
+| `form` | The form container |
+| `input` | All input, textarea, and select elements |
+| `label` | All field labels |
+| `submit-button` | The submit button |
+| `section-button` | Next/back buttons on multi-section forms |
+| `{type}-input` | Input by field type, e.g. `email-input`, `text-input` |
+| `{type}-label` | Label by field type, e.g. `email-label` |
+| `consent-input` | Consent checkbox inputs |
+| `promo-card` | Promo section cards |
+| `success-icon` | Checkmark icon on the success page |
+| `success-heading` | Heading on the success page |
+| `success-body` | Body text on the success page |
+
+### Scope styles to one specific form
+
+When you have multiple forms on the same page, add the form ID to your `::part()` selector to target only that form. The form ID is the `FormConfigID-...` value in your embed code.
+
+```css
+/* Only affect the contact form */
+.crm-form-host::part(FormConfigID-abc123 input) {
+  border-color: #7c3aed;
+}
+
+/* Only affect the newsletter form */
+.crm-form-host::part(FormConfigID-xyz456 submit-button) {
+  background-color: #059669;
+}
+```
+
+:::tip
+You can find your form ID by inspecting the embedded form in your browser's developer tools. Look for the element `<div class="crm-form-host" data-form-id="FormConfigID-...">`.
+:::

--- a/docusaurus/docs/business-app/crm/forms/index.md
+++ b/docusaurus/docs/business-app/crm/forms/index.md
@@ -106,9 +106,9 @@ Yes! You can add media queries and responsive CSS rules in the Custom CSS sectio
 </details>
 
 <details>
-<summary>What CSS classes can I target for form styling?</summary>
+<summary>What CSS can I use to style my form from my website?</summary>
 
-You can target standard form elements like `.form-container`, `input[type="text"]`, `input[type="email"]`, `.submit-button`, and other standard HTML form elements. Use your browser's developer tools to inspect the form structure.
+CSS entered in the **Design tab** (Custom CSS editor) works normally — you can use standard selectors like `input`, `label`, or `.submit-button` there. If you want to apply styles from your website's own stylesheet, use the `::part()` pseudo-element instead, since the form renders in an isolated container that blocks outside selectors. See [Style a form from your website's stylesheet](form-builder.md#style-a-form-from-your-websites-stylesheet) for the full list of available part names and examples.
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- Adds a "Embed multiple forms on the same page" subsection to Step 4 in `form-builder.md`, showing the `async data-crm-form-widget` pattern
- Adds a new "Style a form from your website's stylesheet" section explaining why plain CSS selectors are blocked by the form's isolated container and how to use `::part()` from the host page, including a part-names reference table and per-instance scoping
- Updates the FAQ entry in `index.md` that listed incorrect CSS class names (`.form-container`, `.submit-button`) — clarifies the Design-tab CSS vs host-page CSS distinction and links to the new section

## Test plan

- [ ] Review rendered output locally (`npm run start` from `docusaurus/`)
- [ ] Confirm tables, code blocks, and callouts render correctly
- [ ] Confirm the FAQ anchor link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)