### PR TITLE
docs: Vibe June 8 updates — stop button, Supabase secrets, country domains, and more

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/connectors/supabase.md
+++ b/docusaurus/docs/business-app/ai/vibe/connectors/supabase.md
@@ -39,3 +39,7 @@ You need an existing Supabase project with three values ready:
 7. Click **Add Connection**.
 
 Once connected, enable the Supabase connector in your Vibe settings to start building against your project.
+
+## Secrets and API keys
+
+When your Vibe app needs a Supabase API key, Vibe shows you exactly which secret to add and links directly to the right page in your Supabase dashboard. Your keys go into your project's environment — never into the chat. If a required key is missing, your app surfaces a clear error message instead of failing silently.

--- a/docusaurus/docs/business-app/ai/vibe/getting-started.md
+++ b/docusaurus/docs/business-app/ai/vibe/getting-started.md
@@ -23,7 +23,7 @@ You see your Vibe project list. If this is your first time, the list is empty an
 
 ## Step 2: Create a New Project
 
-Once you're in Vibe, you'll see a project list. Click **+ Create a new app** to create your first application.
+Once you're in Vibe, you'll see a project list. Each card shows a live preview thumbnail of the app you built. Click **+ Create a new app** to create your first application.
 
 ![Empty Vibe project list with the Create a new app button](./img/project-list.png)
 
@@ -76,6 +76,8 @@ After you submit your prompt, Vibe runs through a consistent sequence you can fo
 
 The chat auto-scrolls to follow new events as they arrive. If you scroll up to read older context, follow-tail pauses; scroll back near the bottom and it resumes.
 
+While a generation is in progress, you can type your next message in the chat input — it won't interrupt the current run. To stop a run early, click the **Stop** button in the chat input. The generation halts almost immediately, the last working preview stays on screen, and your original prompt returns to the input so you can edit and resend.
+
 ## Step 5: Iterate and Refine
 
 Your first generation is just the starting point. Use follow-up prompts to refine your application:
@@ -99,6 +101,8 @@ The chat panel shows your conversation history with Vibe. Each exchange shows:
 - **Inline screenshots** — When Vibe captures a reference site or runs a visual check, the screenshot appears inline in the status row.
 - **Feedback buttons** — Thumbs up/down to rate each generation.
 
+On projects with multiple collaborators, each prompt shows the sender's avatar, name, and a timestamp, so it's clear who asked for what.
+
 ### Chat Input
 
 At the bottom of the chat panel, you find:
@@ -107,9 +111,11 @@ At the bottom of the chat panel, you find:
 |---------|-------------|
 | **Text input** | Type your prompt here. Press Enter to send, Shift+Enter for a new line. Paste a URL in the input to clone a reference site (see [Cloning a reference site](./guides/clone-from-url.md)). |
 | **+ (image)** | Attach screenshots or mockups to show Vibe what you want. |
+| **Visual edits** | Toggle design mode on or off. When on, click any element in the live preview to select it; toggle off to return to prompting. |
 | **Mode selector** | Pick the generation mode for the next prompt. |
 | **Microphone** | Record voice input. Vibe transcribes your speech into a prompt. |
 | **Send** | Submit the prompt to Vibe. |
+| **Stop** | (Appears during a generation.) Halt the current run. The last working preview stays on screen and your prompt returns to the input. |
 
 ![The Vibe chat input with a sample prompt typed in, showing the image, mode, microphone, and send controls](./img/chat-input.png)
 

--- a/docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/clone-from-url.md
@@ -17,7 +17,7 @@ When your prompt includes a URL, Vibe captures four things from the page:
 - **The HTML structure** as a layout specification. Vibe reads the section ordering, the grid layouts, the component patterns.
 - **The text content as markdown.** Headlines, body copy, link text, button labels.
 
-The screenshot is what Vibe *sees*; the HTML is what it *reads*; the branding is what it *applies*; the markdown is what it *writes back*. Together those four channels are enough to reconstruct a faithful version of the page.
+The screenshot is what Vibe *sees*; the HTML is what it *reads*; the branding is what it *applies*; the markdown is what it *writes back*. Together those four channels are enough to reconstruct a faithful version of the page. Vibe reads only what it needs from each page, so cloning runs are fast and credit-efficient.
 
 ## A simple clone
 

--- a/docusaurus/docs/business-app/ai/vibe/guides/custom-domain.mdx
+++ b/docusaurus/docs/business-app/ai/vibe/guides/custom-domain.mdx
@@ -5,7 +5,7 @@ sidebar_position: 4
 
 # Custom Domains
 
-Every Vibe project gets a default published URL automatically. On the Professional plan, you can also publish to a domain you own. TLS is provisioned automatically for both your default URL and any custom domain, so you don't need to purchase or manage certificates.
+Every Vibe project gets a default published URL automatically. On the Professional plan, you can also publish to a domain you own — including country and regional domains like `.co.uk`, `.com.au`, and `.org.uk`. TLS is provisioned automatically for both your default URL and any custom domain, so you don't need to purchase or manage certificates.
 
 ## Your default domain
 
@@ -32,7 +32,7 @@ Custom domains require the Professional plan. If you're on a different plan, upg
 
 <!-- screenshot needed: DNS verification records panel in Publish workflow -->
 
-Your app becomes available at your custom domain after the certificate is provisioned. If you add a `www` subdomain, Vibe automatically redirects it to your main domain.
+Your app becomes available at your custom domain after the certificate is provisioned. If you add a `www` subdomain, Vibe automatically redirects it to your main domain. Country and regional domains (`.co.uk`, `.com.au`, `.org.uk`, and similar) are fully supported — DNS verification, SSL provisioning, and www redirects work the same way as `.com` domains.
 
 ## Remove a Custom Domain
 

--- a/docusaurus/docs/business-app/ai/vibe/guides/visual-editor.md
+++ b/docusaurus/docs/business-app/ai/vibe/guides/visual-editor.md
@@ -6,7 +6,7 @@ unlisted: false
 
 # Visual Editor
 
-Vibe includes a visual editor that lets you customize your application's appearance without writing prompts or code. Turn on the **Visual edits** button in the chat composer to enter design mode.
+Vibe includes a visual editor that lets you customize your application's appearance without writing prompts or code. Toggle the **Visual edits** button in the chat composer to flip design mode on and off — click elements in the live preview when it's on, then toggle it off to return to prompting. No hunting for a separate control.
 
 <!-- THEMES: restore the following image and section when themes feature launches
 ![The Vibe editor in design mode: the left panel shows the Appearance Light/Dark toggle, the current theme, and the color palette list (Default, Glacier, Harvest, Lavender, and more), with the Visual edits button active in the chat composer below it.](../img/design-mode-themes.png)

--- a/docusaurus/docs/business-app/ai/vibe/index.md
+++ b/docusaurus/docs/business-app/ai/vibe/index.md
@@ -36,7 +36,7 @@ See [Use Cases](./use-cases/index.md) for step-by-step walkthroughs of these and
 ## Key Features
 
 ### Chat-Based Development
-Describe what you want in the chat panel. Vibe interprets the request and generates or modifies the application. Send follow-up messages to refine the result. Vibe's chat supports multiple languages, including French, Spanish, German, Italian, Czech, Chinese, Japanese, and Korean.
+Describe what you want in the chat panel. Vibe interprets the request and generates or modifies the application. Send follow-up messages to refine the result. Vibe's chat supports multiple languages, including French, Spanish, German, Italian, Czech, Chinese, Japanese, and Korean. On projects with multiple collaborators, each prompt shows the sender's avatar, name, and a timestamp.
 
 ### Business Knowledge
 Every project has a built-in knowledge base pre-loaded with the location's Business Profile — name, services, hours, contact info, brand voice, and FAQs. When you ask Vibe to build a Contact page or add an About section, it fills in real details about the business instead of placeholder text. You can extend the knowledge base from the project settings page by adding URLs, files, or notes. See [Business Knowledge](./guides/business-knowledge.md).
@@ -51,7 +51,7 @@ Every generation produces a structured plan that drives the run. The plan, the a
 Paste a URL and Vibe captures the screenshot, branding, layout, and content of that page, then scaffolds a faithful clone you can refine. The captured colors become a custom theme automatically. See [Cloning a reference site](./guides/clone-from-url.md).
 
 ### Visual Editor
-Turn on the **Visual edits** button in the chat composer to make targeted edits by clicking elements in the preview. When you click an element, Vibe gets exact source context (file, line, JSX tag, classes), so any change you ask for lands precisely on the element you selected. See [Visual Editor](./guides/visual-editor.md).
+Toggle **Visual edits** in the chat composer to flip design mode on and off. When on, click any element in the live preview to select it — Vibe gets exact source context (file, line, JSX tag, classes), so any change you ask for lands precisely on the element you selected. Toggle it off to return to regular prompting. See [Visual Editor](./guides/visual-editor.md).
 
 <!-- THEMES: restore the following to the section above when themes feature launches:
 "browse pre-built color themes, toggle between light and dark mode, and make targeted edits..."
@@ -85,7 +85,7 @@ When you send a prompt, Vibe's orchestrator coordinates multiple AI agents:
 1. **You describe** what you want in the chat panel.
 2. **Clarification** — If the request is ambiguous, Vibe asks structured questions before continuing.
 3. **Planning** — A planning agent produces a structured plan describing the architecture, navigation, and which files will be touched. The plan also commits to a named design system — palette, fonts, and UI primitives — before any code is written.
-4. **Generation** — A generation agent writes the code file by file, applying the theme, generating images, and editing components in real time. Type-check and build verification run continuously to catch and fix issues.
+4. **Generation** — A generation agent writes the code file by file, applying the theme, generating images, and editing components in real time. Type-check and build verification run continuously to catch and fix issues. You can stop the run at any time by clicking **Stop** — the last working preview stays on screen and your prompt returns to the input.
 5. **Validation** — Vibe takes a screenshot of the rendered preview and runs a build check. Before declaring the task complete, Vibe runs a final type check and self-corrects any remaining issues — up to three rounds. If they can't be resolved, the run finishes with a "verified with issues" status instead of a silent claim of success.
 6. **Preview** — The live preview updates as soon as the build is clean.
 7. **Iteration** — You review the result and send follow-up prompts to refine it. Runtime errors in the preview trigger an auto-fix banner.


### PR DESCRIPTION
## Summary

- **Stop button** — `getting-started.md` and `index.md` updated to document the new Stop control in the chat input, and the ability to type your next message while a generation is running
- **Supabase guided secret setup** — `connectors/supabase.md` adds a new "Secrets and API keys" section explaining that Vibe guides you to the right Supabase dashboard page and keeps keys out of chat
- **Country/regional custom domains** — `guides/custom-domain.mdx` updated to call out `.co.uk`, `.com.au`, `.org.uk` and similar domains, with a note that SSL and www redirects work the same as `.com`
- **Collaborator attribution** — `getting-started.md` and `index.md` updated to document who-said-what display (avatar, name, timestamp) on multi-collaborator projects
- **Visual edits toggle** — `guides/visual-editor.md` and `getting-started.md` updated to describe the toggle as two-way (on to click elements, off to return to prompting)
- **Project card thumbnails** — `getting-started.md` Step 2 updated to mention live preview thumbnails on project cards
- **Faster cloning** — `guides/clone-from-url.md` updated to note that cloning reads only what's needed per page

## Test plan

- [ ] Review each changed file for accuracy against the June 8 release notes
- [ ] Confirm no Vendasta branding or non-evergreen language introduced
- [ ] Verify build passes (no broken links or frontmatter issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)