### PR TITLE
Add Meeting Scheduler setup video to Yesware meeting-schedule page

### DIFF
--- a/docusaurus/docs/yesware/meeting-scheduler/index.mdx
+++ b/docusaurus/docs/yesware/meeting-scheduler/index.mdx
@@ -7,6 +7,30 @@ description: "Complete guide to setting up and using Meeting Scheduler in Yeswar
 
 Meeting Scheduler provides reps with a complete automated workflow for booking meetings with customers and prospects, eliminating the back and forth emails in booking a meeting by creating a scheduling link you can send to your recipients, which allows them to book meetings directly on your calendar.
 
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/ps9566nk3d?web_component=true&seo=true"
+      title="How to Set Up Meeting Scheduler in Gmail"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
+
 ## Setting Up Meeting Scheduler
 
 To set up Meeting Scheduler, open a new email message and click on the calendar icon in the Yesware Sidebar to launch the Meeting Scheduler menu. Next, click the gear icon to open up the [Meeting Scheduler settings](https://app.yesware.com/account/meeting_scheduler).


### PR DESCRIPTION
## Summary
Adds a Wistia video embed ("How to Set Up Meeting Scheduler in Gmail") to the Meeting Scheduler article
Video is placed before the written setup steps so users can choose to watch or read
File was already .mdx, no conversion needed

## Test plan
 Confirm video renders at /yesware/meeting-scheduler in local dev
 Confirm no build errors