### PR TITLE
docs: add Enhanced Dashboard Overview card article

### DIFF
--- a/docusaurus/docs/wordpress-hosting/enhanced-dashboard/dashboard-overview.md
+++ b/docusaurus/docs/wordpress-hosting/enhanced-dashboard/dashboard-overview.md
@@ -7,4 +7,26 @@ tags: [wordpress-hosting, dashboard, overview]
 keywords: [WordPress overview, site preview, PHP version, WP core update, plugin updates, theme updates, flush cache, CDN]
 ---
 
-Documentation coming soon.
+The **Overview** card is the home of your dashboard. It shows a live preview of your site and gives you one-click access to the maintenance actions you'll use most often.
+
+![Overview card with site preview, PHP version, WP core updates, plugin and theme updates, Flush Cache, and CDN toggle](img/overview-card.png)
+
+## What you can see and do
+
+- **Site preview and live URL** — A thumbnail of your homepage and a clickable link to your live site.
+- **PHP version** — Click **Change** to switch PHP. Pick from supported versions; older versions are marked **Deprecated**.
+- **WP core updates** — Click **Update** to install a new WordPress version. A green checkmark means you're current.
+- **Plugin updates** — Click **Update** to open the Plugins & Themes panel and apply pending plugin updates.
+- **Theme updates** — Click **Update** to apply pending theme updates from the same panel.
+- **Flush Cache** — Clears all cached pages on your site. Use after publishing changes that aren't appearing live.
+- **CDN** — Toggle the Content Delivery Network on or off. Leave it on in normal use for faster page loads worldwide.
+
+The **WordPress Admin** button in the page header opens `/wp-admin` in a new tab with one-click login.
+
+## Keep your site up to date
+
+Plugin and theme updates often include security fixes. Out-of-date plugins are the most common cause of a hacked WordPress site, so install updates regularly — at minimum once a month, ideally as soon as updates are available.
+
+:::tip
+Create a backup before installing a WordPress core, plugin, or theme update. See [Backups](./backups) for the one-click on-demand backup.
+:::


### PR DESCRIPTION
## Summary

Adds the help article for the **Overview** card on the new WordPress Hosting Enhanced Dashboard. Replaces the stub created by the scaffold PR with full content, including the screenshot already in `img/`.

## Test plan

- [ ] Visit `/wordpress-hosting/enhanced-dashboard/dashboard-overview` — article renders with the screenshot
- [ ] Confirm sidebar label appears in the correct position under **Enhanced Dashboard**
- [ ] Internal links (where present) resolve to existing pages
- [ ] Cloud Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)