### PR TITLE
docs: add Enhanced Dashboard Email History card article

### DIFF
--- a/docusaurus/docs/wordpress-hosting/enhanced-dashboard/email-history.md
+++ b/docusaurus/docs/wordpress-hosting/enhanced-dashboard/email-history.md
@@ -7,4 +7,25 @@ tags: [wordpress-hosting, dashboard, email, deliverability]
 keywords: [email history, transactional email, email log, email delivery, troubleshoot email]
 ---
 
-Documentation coming soon.
+The **Email History** card shows every email your site has sent — form submissions, order confirmations, comment notifications, and anything else triggered by WordPress or your plugins. Available on both **Standard** and **Pro** editions.
+
+Use it to confirm an email went out, debug missing messages, or audit what your site is sending.
+
+![Email History panel with date, subject, to, and from columns](img/email-history-panel.png)
+
+## What you see
+
+- **Emails sent** — Total messages sent from your site.
+- **Last:** — Timestamp of the most recent email.
+
+Click **View** to open the full email log. Each row shows the **Date**, **Subject**, **To**, and **From**. Click a row to open the email's full detail, with **Details** and **Events** tabs (sent, delivered, opened, bounced).
+
+## Common uses
+
+- Confirm a contact form submission was delivered.
+- Audit what your site is sending and how often.
+- Diagnose deliverability issues for any notification your site sends.
+
+:::tip
+If a recipient says they didn't get an email, open the email in the log and check the **Events** tab. A "delivered" event means the email reached their mail server — the issue is most likely a spam filter on their side.
+:::


### PR DESCRIPTION
## Summary

Adds the help article for the **Email History** card on the new WordPress Hosting Enhanced Dashboard. Replaces the stub created by the scaffold PR with full content, including the screenshot already in `img/`.

## Test plan

- [ ] Visit `/wordpress-hosting/enhanced-dashboard/email-history` — article renders with the screenshot
- [ ] Confirm sidebar label appears in the correct position under **Enhanced Dashboard**
- [ ] Internal links (where present) resolve to existing pages
- [ ] Cloud Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)