### PR TITLE
docs: add Enhanced Dashboard Plugins and Themes card article

### DIFF
--- a/docusaurus/docs/wordpress-hosting/enhanced-dashboard/plugins-and-themes.md
+++ b/docusaurus/docs/wordpress-hosting/enhanced-dashboard/plugins-and-themes.md
@@ -7,4 +7,40 @@ tags: [wordpress-hosting, dashboard, plugins, themes]
 keywords: [WordPress plugins, install plugin, update plugin, activate plugin, deactivate plugin, WordPress theme]
 ---
 
-Documentation coming soon.
+The **Plugins & Themes** panel lets you manage every plugin on your site and your active theme — install, update, activate, and deactivate without going into WordPress admin.
+
+![Plugins & Themes panel with active and inactive plugins and the current theme](img/plugins-themes-panel.png)
+
+## What you see
+
+- **+ Install** — Install a new plugin.
+- **Active Plugins** — Plugins currently running on your site. Each row shows the version and either **Up to date** or an **Update v[version]** button.
+- **Inactive Plugins** — Installed but not running. Each row has an **Activate** button.
+- **Theme** — The active theme, its version, and an **Active** badge.
+
+## Update a plugin
+
+Click **Update v[new version]** on the plugin's row. The update completes in a few seconds and the badge changes to **Up to date**.
+
+## Activate or deactivate a plugin
+
+- To activate, click **Activate** on an inactive plugin's row.
+- To deactivate, open the plugin's actions in WordPress Admin.
+
+## Install a new plugin
+
+1. Click **+ Install** at the top of the panel.
+2. Search or browse for the plugin you want.
+3. Click **Install** on the plugin's card.
+
+The plugin appears under **Inactive Plugins**. Click **Activate** when you're ready.
+
+:::tip
+Create a backup before installing or updating a plugin. Test major updates on [staging](./staging) first.
+:::
+
+## Keep plugins healthy
+
+- **Update regularly.** Plugin updates often include security fixes.
+- **Remove what you don't use.** Inactive plugins left unmaintained become a security risk.
+- **Stick to well-supported plugins.** A plugin that hasn't been updated in years is more likely to break with a WordPress core update.


### PR DESCRIPTION
## Summary

Adds the help article for the **Plugins & Themes** card on the new WordPress Hosting Enhanced Dashboard. Replaces the stub created by the scaffold PR with full content, including the screenshot already in `img/`.

## Test plan

- [ ] Visit `/wordpress-hosting/enhanced-dashboard/plugins-and-themes` — article renders with the screenshot
- [ ] Confirm sidebar label appears in the correct position under **Enhanced Dashboard**
- [ ] Internal links (where present) resolve to existing pages
- [ ] Cloud Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)