### PR TITLE
fix: correct internal documentation links to use directory paths

### DIFF
--- a/docusaurus/docs/business-app/administration/conversations-settings.md
+++ b/docusaurus/docs/business-app/administration/conversations-settings.md
@@ -46,7 +46,7 @@ Connect messaging channels so they appear in your unified inbox:
 - [Email Configuration](./email/email-configuration)
 - [SMS Configuration](./sms_configuration.md)
 - [Conversations overview](../conversations/index.mdx)
-- [Web Chat](../conversations/web-chat/index.mdx)
+- [Web Chat](../conversations/web-chat)
 - [Facebook Messenger](../conversations/facebook-messenger.mdx)
 - [Instagram Messages](../conversations/instagram-messenger.mdx)
 - [WhatsApp for Conversations AI](../conversations/whatsapp-for-inbox.mdx)

--- a/docusaurus/docs/business-app/conversations/web-chat/track-web-chat-events-in-google-analytics-using-tag-manager.mdx
+++ b/docusaurus/docs/business-app/conversations/web-chat/track-web-chat-events-in-google-analytics-using-tag-manager.mdx
@@ -18,7 +18,7 @@ Before beginning this integration, ensure you have:
 3. A configured Google Analytics property
 
 :::info
-If you haven't set up your web chat widget yet, start with the [Web Chat Setup & Usage guide](./index.mdx) before configuring event tracking.
+If you haven't set up your web chat widget yet, start with the [Web Chat Setup & Usage guide](../web-chat) before configuring event tracking.
 :::
 
 ## How web chat events work
@@ -33,7 +33,7 @@ dataLayer.push({
 ```
 
 :::tip
-The web chat widget must load after your GTM container initializes. If you're installing via [Google Tag Manager](./index.mdx#for-google-tag-manager), ensure the GTM container loads before the chat widget code.
+The web chat widget must load after your GTM container initializes. If you're installing via [Google Tag Manager](../web-chat), ensure the GTM container loads before the chat widget code.
 :::
 
 ## Setting up event tracking

--- a/docusaurus/docs/business-app/getting-started-with-business-app.md
+++ b/docusaurus/docs/business-app/getting-started-with-business-app.md
@@ -122,7 +122,7 @@ Connections bring your most important business data into one place. When you con
 Common connections to set up early:
 
 - **Google Business Profile**: Syncs location details and visibility metrics. Data can appear in your Executive Report within about 5 minutes. For setup details, see [Business Profile](./administration/business_profile.mdx) and [Integrations](./administration/connections/index.md).
-- **QuickBooks Online**: Import existing customers, automate review requests from invoiced customers, and surface financial insights. See [QuickBooks integration](./administration/integrations/quickbooks.mdx) for connection steps.
+- **QuickBooks Online**: Import existing customers, automate review requests from invoiced customers, and surface financial insights. See [QuickBooks integration](./administration/integrations/quickbooks) for connection steps.
 
 [Back to checklist](#getting-started-checklist)
 
@@ -130,7 +130,7 @@ Common connections to set up early:
 
 ## Step 4: Set up AI and web chat
 
-[AI Workforce](./ai/ai-workforce/ai_workforce_overview.md) lets you automate conversations, capture leads, and answer customer questions 24/7. The [Web Chat](./conversations/web-chat/index.mdx) widget engages website visitors and sends leads directly to your Conversations inbox.
+[AI Workforce](./ai/ai-workforce/ai_workforce_overview.md) lets you automate conversations, capture leads, and answer customer questions 24/7. The [Web Chat](./conversations/web-chat) widget engages website visitors and sends leads directly to your Conversations inbox.
 
 ### Meet your AI Workforce
 


### PR DESCRIPTION
## Summary
Updated internal documentation links across multiple files to use directory paths instead of `index.mdx` file references. This improves link consistency and maintainability in the Docusaurus documentation structure.

## Changes Made
- **Web Chat event tracking guide**: Updated two links to Web Chat setup documentation
  - Changed `./index.mdx` to `../web-chat` (relative directory path)
  - Changed `./index.mdx#for-google-tag-manager` to `../web-chat` (removed anchor reference to index file)

- **Getting Started guide**: Updated Web Chat widget link
  - Changed `./conversations/web-chat/index.mdx` to `./conversations/web-chat` (directory path)

- **Conversations Settings**: Updated Web Chat reference link
  - Changed `../conversations/web-chat/index.mdx` to `../conversations/web-chat` (directory path)

- **Getting Started guide**: Updated QuickBooks integration link
  - Changed `./administration/integrations/quickbooks.mdx` to `./administration/integrations/quickbooks` (directory path)

## Implementation Details
These changes align with Docusaurus best practices where links to index files within directories can be simplified to directory paths. The documentation will continue to resolve correctly while improving link clarity and reducing maintenance burden if file names change in the future.

https://claude.ai/code/session_017C8jQDjPgHZzSEqJvnQXX8