### PR TITLE
Docs: Hide AI Credits section when no entitlements (BILL-3242)

### DIFF
--- a/docusaurus/docs/business-app/ai/vibe/credits.md
+++ b/docusaurus/docs/business-app/ai/vibe/credits.md
@@ -19,7 +19,7 @@ A credit is used each time you send a message to Vibe. How many credits a messag
 | Generate a new component | "Add a contact form and connected to my CRM" | ~300 |
 | Build a multi-page website | "Create a 4-page business website with my business profile" | ~500 |
 
-Credits are tied to the account they were issued to and cannot be transferred to other accounts. You can check your remaining balance at any time under **Administration > AI Settings > Credits**.
+Credits are tied to the account they were issued to and cannot be transferred to other accounts. You can check your remaining balance under **Administration > AI Settings > Credits** — this section appears only when you have an active product that uses AI credits.
 
 When your included credits are used up, Vibe opens an Upgrade dialog where you can complete checkout directly in Business App — no support ticket or wait time required.
 


### PR DESCRIPTION
## JIRA

[BILL-3242 — Hide AI credits page in settings if NO products with entitlements](https://vendasta.jira.com/browse/BILL-3242)

---

## Change Classification

**UI/UX visibility change** — The AI Credits section under Administration > AI Settings is now conditionally hidden when the user has no active products with AI credit entitlements.

**Repo:** Business App only. This is a Business App end-user Settings page change. No Partner Center UI is affected.

---

## Summary of Documentation Updates

**File updated:** `docusaurus/docs/business-app/ai/vibe/credits.md`

**What changed:** A single sentence describing how to access the Credits balance was updated to reflect that the **Administration > AI Settings > Credits** section is only visible when the user has an active product with AI credits.

**Before:**
> You can check your remaining balance at any time under **Administration > AI Settings > Credits**.

**After:**
> You can check your remaining balance under **Administration > AI Settings > Credits** — this section appears only when you have an active product that uses AI credits.

---

## Existing Docs Updated vs. New Docs Created

- ✅ **Existing doc updated** — `credits.md` already covered the AI credits system; this is a targeted one-line edit.
- No new pages created.

---

## Placement Reasoning

The only documentation that references the Credits Settings UI path is `credits.md`. The change is scoped to one sentence in the "How Credits Work" section, where the Settings navigation path is described.

---

## Acceptance Criteria Coverage

| AC | Documented |
|----|-----------|
| No entitlement → do not show AI credits on the settings page | ✅ Updated sentence clarifies the section appears only when an active product with AI credits is present |

---

## Figma / Visual Inputs

None provided in the JIRA ticket.

---

## Skills Used

- `pre-push-validation` — ran on modified file, all checks passed.

---

## Assumptions / Limitations

- The change describes end-user-visible behavior only (no Vendasta branding, no internal references).
- No Partner Center update required — this ticket is scoped to the Business App Settings UI.

---

@ahnikakuse @haleyserrano @maryam6samadi

> **Code author / suggested reviewer:** @mykytabatrak

---
_Generated by [Claude Code](https://claude.ai/code/session_016XKH5vXej7gtLh3vXCJ7CG)_