### PR TITLE
Docs: Add multi-location web chat widget article (WOW-2515)

### DIFF
--- a/docusaurus/docs/business-app/conversations/web-chat/multi-location-web-chat.md
+++ b/docusaurus/docs/business-app/conversations/web-chat/multi-location-web-chat.md
@@ -1,0 +1,29 @@
+---
+title: Multi-Location Web Chat Widget
+sidebar_label: Multi-Location Web Chat
+description: Set up a brand-level web chat widget that lets website visitors choose a location and chat with that location's AI Receptionist
+---
+
+If your business has multiple locations, you can embed a single web chat widget on your main brand website. Visitors choose a location from within the widget, then connect directly with that location's AI Receptionist.
+
+This widget operates at the brand level and is separate from each individual location's web chat widget. It has its own embed code.
+
+## Set up the widget
+
+The multi-location widget is configured from your group's setup page in Multi-Location Business App.
+
+During setup, a table lists each of your locations alongside its **AI Employee** — this shows which AI Receptionist handles chats for that location. Review this column to confirm the correct AI Receptionist is assigned to each location before going live.
+
+## Get the embed code
+
+The group setup page includes an embed code you copy and paste to install the widget on your brand website.
+
+1. On the group setup page, scroll to the embed code section.
+2. Copy the code snippet.
+3. Paste it into your brand website.
+
+For platform-specific installation steps (WordPress, Shopify, Wix, and others), see [Web Chat Setup & Usage](./index.mdx).
+
+## How visitors experience it
+
+When a visitor opens the chat widget on your brand website, they see a list of your locations. After selecting one, they chat directly with that location's AI Receptionist.


### PR DESCRIPTION
## JIRA

[WOW-2515 — Multi-location refinements](https://vendasta.jira.com/browse/WOW-2515)
Parent epic: [WOW-2401 — Multi-Location Web Chat Widget (MVP)](https://vendasta.jira.com/browse/WOW-2401)

---

## Change classification

**UI / feature behavior change** — Business App end-user facing

---

## Repo

**Business App docs** (`vendasta/businessapp-docs`)

---

## Summary

Created a new documentation page for the multi-location web chat widget in the existing `conversations/web-chat/` section.

**File added:**
`docusaurus/docs/business-app/conversations/web-chat/multi-location-web-chat.md`

---

## What changed

- **New page created** (no existing multi-location widget docs existed in either repo)
- Documents the brand-level web chat widget for businesses with multiple locations
- Covers the embed code now visible on the group setup page (WOW-2515 refinement #1)
- Documents the **AI Employee** column label in the location selection table (WOW-2515 refinement #2 — renamed from "status")
- Describes the visitor experience: location picker → AI Receptionist chat

---

## Placement reasoning

The new page lives alongside the existing single-location web chat article in `conversations/web-chat/`. The multi-location widget is a distinct feature (brand-level, separate embed code, different setup flow) that warrants its own page rather than being appended to the existing article.

---

## Acceptance criteria coverage

| Criterion | Documented |
|-----------|-----------|
| Embed code visible on group setup page | ✅ "The group setup page includes an embed code you copy and paste to install the widget" |
| Column title is "AI Employee" (not "status") | ✅ "a table lists each of your locations alongside its **AI Employee**" |
| Brand-level widget with own embed code | ✅ "operates at the brand level and is separate from each individual location's web chat widget" |
| Visitor location picker experience | ✅ "Visitors choose a location from within the widget, then connect directly with that location's AI Receptionist" |

---

## Figma / visual inputs

None provided in the JIRA ticket. Documentation based on JIRA description and epic content only.

---

## Skills used

- `pre-push-validation` — frontmatter, tag, and link validation passed

---

## Assumptions / limitations

- Exact navigation path to the group setup page was not specified in the JIRA ticket. The doc describes the feature without step-by-step navigation clicks to avoid documenting incorrect paths.
- Developer on this ticket: Greg Brownell (gbrownell@vendasta.com) — GitHub username not found; please add as reviewer manually if desired.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dam5bWWQhbLPmyMwxUFCW8)_