### PR TITLE
fix: remove orphaned Demo heading from notetaker-settings

### DIFF
--- a/docusaurus/docs/business-app/crm/My meetings/notetaker-settings.mdx
+++ b/docusaurus/docs/business-app/crm/My meetings/notetaker-settings.mdx
@@ -51,8 +51,6 @@ In the `Bot Settings` section, you can:
 Review your bot settings regularly to ensure they reflect your current meeting requirements.
 :::
 
-## Demo
-
 {/* TODO: Replace this Google Drive embed with a Wistia video — see .cursor/rules/wistia-video-embedding.mdc for the required format.
 <div style={{position: "relative", paddingBottom: "56.25%", height: 0}}>
   <iframe 


### PR DESCRIPTION
## Summary

- Removes the `## Demo` heading from `notetaker-settings.mdx` that was left with no content after the Google Drive iframe was commented out in the previous PR (#598).

🤖 Generated with [Claude Code](https://claude.com/claude-code)