### PR TITLE
Docs: Add Hide Advanced Login toggle location and behavior (WSP-3470)

### DIFF
--- a/docusaurus/docs/wordpress-hosting/advanced-tools/advanced-login.md
+++ b/docusaurus/docs/wordpress-hosting/advanced-tools/advanced-login.md
@@ -4,13 +4,22 @@ sidebar_label: "Advanced Login"
 description: "Learn how to configure captcha protection and advanced login options for your WordPress admin page."
 ---
 
-If the Advanced Login feature is enabled, logging into the WordPress dashboard via SSO may be affected when a reCAPTCHA is set up on the WordPress login page.
+## Hide Advanced Login
+
+The **Hide Advanced Login** toggle controls whether users can access the WordPress admin panel directly via `/wp-admin`. When enabled, direct access is blocked and users must sign in through the WordPress Hosting dashboard.
+
+To find the toggle, navigate to **My Products > WordPress Hosting**, select your site, and open **Advanced Tools**.
 
 ![Advanced Login toggle in the WordPress Hosting dashboard](./img/advanced-login/hide-advanced-login-toggle.png)
 
-When the toggle is turned off, you can log in directly using `www.domainname.com/wp-admin`.
+- **Enabled**: Direct `/wp-admin` access is blocked. Users must log in through the WordPress Hosting dashboard.
+- **Disabled**: Users can log in directly at `www.domainname.com/wp-admin`.
 
-### Enhanced captcha settings
+:::info
+When **Hide Advanced Login** is enabled, logging into the WordPress dashboard via SSO may be affected if a reCAPTCHA is also configured on the WordPress login page.
+:::
+
+## Enhanced captcha settings
 
 You can configure Enhanced Captcha from your WordPress dashboard under **Settings > General**. From here, you can enable or disable captcha and adjust the failed login attempt threshold.
 


### PR DESCRIPTION
## JIRA

[WSP-3470 — Hide Advanced login toggle missing in new WP Cloud dashboard](https://vendasta.jira.com/browse/WSP-3470)

---

## Change classification

**UI / Feature behavior change** — The Hide Advanced Login toggle, previously only accessible in the old WordPress Hosting dashboard, is now also present in the new WP Cloud dashboard under **Advanced Tools**. The toggle reads from and writes to the same backing store so the state is consistent across both dashboards.

---

## Repo targeted

**Business App** (`businessapp-docs`) — The Hide Advanced Login toggle is a feature of the WordPress Hosting product and is documented under `docusaurus/docs/wordpress-hosting/advanced-tools/`.

The Partner Center repo has no dedicated WP Cloud / WordPress Hosting Advanced Tools documentation and requires no changes.

---

## Summary of changes

**Updated:** `docusaurus/docs/wordpress-hosting/advanced-tools/advanced-login.md`

- Added a clear `## Hide Advanced Login` section heading to structure the article
- Added the navigation path users need to locate the toggle: **My Products > WordPress Hosting > [site] > Advanced Tools**
- Clarified the toggle's enabled/disabled behavior with explicit bullet points (previously only the "off" state was described, in a single sentence with no heading)
- Moved the SSO/reCAPTCHA compatibility note into an `:::info` callout for better visibility
- The Enhanced Captcha section is unchanged

---

## Existing docs updated vs. new page created

**Existing page updated.** The article `advanced-login.md` already covered the Hide Advanced Login toggle but lacked a navigation path and a clear description of what the toggle does in each state. No new page was required.

---

## Placement reasoning

The article lives at `wordpress-hosting/advanced-tools/advanced-login.md`, which is the correct location. No structural changes to the sidebar or `_category_.json` were needed.

---

## Acceptance criteria coverage

| # | Acceptance criterion | Documentation impact |
|---|---|---|
| 1 | Toggle is present in new WP Cloud dashboard > Advanced Tools | Navigation path added: **My Products > WordPress Hosting > [site] > Advanced Tools** |
| 2 | Toggle reads initial state from vstore | No user-facing doc change needed (implementation detail; user sees correct state) |
| 3 | Toggling updates vstore, reflected in both dashboards | No user-facing doc change needed (implementation detail) |
| 4 | Existing vstore values backfilled | No user-facing doc change needed (migration detail; users see correct state automatically) |
| 5 | No regression in old dashboard | No doc change needed |

---

## Figma / images

No Figma links or new images were provided or required. The existing screenshot (`hide-advanced-login-toggle.png`) remains accurate.

---

## Skills used

- Repository code search (`mcp__github__search_code`) to locate existing documentation
- `mcp__github__get_file_contents` to read current file content before editing

---

## Assumptions / limitations

- No linked GitHub PRs were found on the JIRA ticket, so no code author was added as reviewer.
- The JIRA assignee is Sreeram P (sparthasarathy@vendasta.com); their GitHub handle could not be confirmed from available data.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiCjQQcX5D6Dq3U7YfFM5u)_