### PR TITLE
docs: article verification batch — June 25, 2026

### DIFF
--- a/docusaurus/docs/business-app/crm/opportunities/create-edit-close.md
+++ b/docusaurus/docs/business-app/crm/opportunities/create-edit-close.md
@@ -8,11 +8,11 @@ description: Create opportunities from the page or CSV import; edit from profile
 
 You can manage opportunities in two views:
 
-**Pipeline View** – Manage opportunities visually by stage. Click `Set up a pipeline` if none exists. Drag and drop opportunities to update their stage. Use filters and search to find records.
+`Pipeline View` – Manage opportunities visually by stage. Click `Set up a pipeline` if none exists. Drag and drop opportunities to update their stage. Use filters and search to find records.
 
 ![Opportunities Pipeline View](../img/opportunities/opportunity-1.png)
 
-**List View** – Click the `List` icon to switch. Configure columns, sort by fields such as expected close date, and use bulk actions.
+`List View` – Click the `List` icon to switch. Configure columns, sort by fields such as expected close date, and use bulk actions.
 
 ![Opportunities List View](../img/opportunities/opportunity-2.png)
 

--- a/docusaurus/docs/business-app/crm/opportunities/index.md
+++ b/docusaurus/docs/business-app/crm/opportunities/index.md
@@ -17,9 +17,9 @@ Managing opportunities lets you visualize, organize, and act on deals across dif
 
 ## What's included
 
-- **Pipeline View** to manage opportunities by stage
-- **List View** with sortable and filterable data
-- **Opportunity Profile Page** with a detailed timeline and linked CRM records
+- `Pipeline View` to manage opportunities by stage
+- `List View` with sortable and filterable data
+- `Opportunity Profile Page` with a detailed timeline and linked CRM records
 - **Manual and Automated Creation** of opportunities
 - **Editable Fields** in both profile and table views
 - **Flexible Closing Options** for won or lost deals
@@ -28,7 +28,7 @@ Managing opportunities lets you visualize, organize, and act on deals across dif
 ## How to access opportunities
 
 1. Go to `CRM` → `Opportunities`.
-2. You'll land on the Pipeline View. Use the List icon to switch to a sortable, filterable table.
+2. You'll land on the `Pipeline View`. Use the List icon to switch to a sortable, filterable table.
 
 ## What's in this section
 

--- a/docusaurus/docs/business-app/crm/opportunities/pipeline-setup.md
+++ b/docusaurus/docs/business-app/crm/opportunities/pipeline-setup.md
@@ -10,7 +10,7 @@ description: Set up pipelines, add and remove stages, and use close probability 
 2. Click the `Set up a pipeline` button. This creates a default pipeline.
 3. Use `Add Stage` to insert new stages.
 4. Use the `X` next to a stage to remove it (except for default stages).
-5. Set a **Close Probability** for each stage to forecast deal success rates.
+5. Set a `Close Probability` for each stage to forecast deal success rates.
 
 ![Pipeline setup](../img/opportunities/pipeline-1.png)
 ![Pipeline stages](../img/opportunities/pipeline-2.png)
@@ -27,8 +27,8 @@ Stages represent how an opportunity moves through your sales process. You can na
 - **Qualified** – The opportunity has been qualified as a potential sale
 - **Proposal** – A proposal has been presented to the potential customer
 - **Negotiation** – Terms are being negotiated
-- **Won** – The opportunity has resulted in a sale (or use **Closed Won**)
-- **Lost** – The opportunity did not result in a sale (or use **Closed Lost**)
+- **Won** – The opportunity has resulted in a sale (or use `Closed Won`)
+- **Lost** – The opportunity did not result in a sale (or use `Closed Lost`)
 
 Moving opportunities through stages helps you track your sales process and spot bottlenecks. Set close probability per stage so the CRM can help you forecast revenue.
 

--- a/docusaurus/docs/business-app/executivereport/advertising.md
+++ b/docusaurus/docs/business-app/executivereport/advertising.md
@@ -32,8 +32,8 @@ You can see what’s happening across your ad channels in one place. That makes 
 ### Connect your ad accounts
 
 1. With Advertising Intelligence active, connect your Facebook Ads and/or Google Ads accounts in the product.
-2. Go to the **Executive Report** in Business App and choose a time period.
-3. In the **Advertising** section, you’ll see **Facebook Ads** and **Google Ads** (depending on which accounts are connected).
+2. Go to the `Executive Report` in Business App and choose a time period.
+3. In the `Advertising` section, you’ll see `Facebook Ads` and `Google Ads` (depending on which accounts are connected).
 
 ### Viewing performance data
 
@@ -41,7 +41,7 @@ In the Executive Report, the Advertising section shows a summary of your Google 
 
 ## When data updates
 
-Advertising data in the Executive Report is updated every Sunday, starting the week after you connect an account. You’ll get regular updates so you can track performance over time.
+The weekly Executive Report is updated and sent on Mondays, starting the week after you connect an account. You'll get regular updates so you can track performance over time.
 
 ## Supported platforms
 


### PR DESCRIPTION
## Summary

- UI formatting fixes across 4 CRM Opportunities articles and the Executive Report Advertising article — bold view/field/section names converted to inline code
- Updated advertising data sync day from Sunday to Monday in the Executive Report Advertising article

## Changes

- **pipeline-setup.md** — `Close Probability`, `Closed Won`, `Closed Lost` → inline code
- **create-edit-close.md** — `Pipeline View`, `List View` → inline code
- **index.md** (Opportunities) — `Pipeline View`, `List View`, `Opportunity Profile Page` → inline code; body reference to Pipeline View formatted
- **advertising.md** — `Executive Report`, `Advertising`, `Facebook Ads`, `Google Ads` → inline code in step instructions; updated data sync day from Sunday to Monday

## Test plan

- [ ] Confirm inline code formatting renders correctly on the live docs site
- [ ] Confirm "X" social platform field label in supported-fields.md (no change made — verified as correct)

Closes #600
Closes #601
Closes #602
Closes #603
Closes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)