### PR TITLE
Docs: Ticket workspace (SNP-4857)

### DIFF
--- a/docusaurus/docs/business-app/tickets/_category_.json
+++ b/docusaurus/docs/business-app/tickets/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Tickets",
+  "position": 8,
+  "collapsed": true,
+  "link": {
+    "type": "doc",
+    "id": "business-app/tickets/index"
+  }
+}

--- a/docusaurus/docs/business-app/tickets/index.md
+++ b/docusaurus/docs/business-app/tickets/index.md
@@ -1,0 +1,30 @@
+---
+title: Tickets
+sidebar_label: Tickets
+description: Manage support tickets from a persistent workspace with a views sidebar and open-ticket tabs.
+tags: [tickets, support, workspace, views]
+keywords: [tickets, support tickets, ticket management, views sidebar, ticket tabs, ticket workspace]
+---
+
+The ticket workspace is a persistent layout for managing support tickets. The sidebar and your open ticket tabs stay in place as you move between the ticket list and individual ticket profiles.
+
+## Views sidebar
+
+The left sidebar shows your available views. Each view is a filtered list of tickets — for example, tickets assigned to you, unassigned tickets, or all open tickets. Select a view to update the ticket list in the main area.
+
+Default views include:
+
+- **My Tickets** — tickets assigned to you
+- **Unassigned** — tickets with no assignee
+- **All Open** — all tickets that are not closed
+- **Escalated** — tickets that have been escalated
+
+## Ticket tabs
+
+The tab bar at the top of the main area tracks the tickets you have open, similar to browser tabs.
+
+- **Open a ticket**: Click a ticket in the list. A tab appears in the tab bar for that ticket.
+- **Switch between tickets**: Click any tab to navigate to that ticket's profile.
+- **Close a ticket**: Click the close icon on a tab to remove it.
+
+Tabs remain open when you switch views in the sidebar or return to the ticket list. Navigating away from a ticket does not close its tab.


### PR DESCRIPTION
## JIRA

[SNP-4857 — Ticket workspace shell](https://vendasta.jira.com/browse/SNP-4857)

---

## Change classification

UI/UX change — new feature documentation

---

## Target repo

**Business App** (`vendasta/businessapp-docs`)

The ticket workspace shell is the BCC (Business App) management UI. The Partner Center "My Tickets" customer portal is separate work and not in scope for this ticket.

---

## Summary

Created a new **Tickets** section in the Business App docs covering the ticket workspace UI introduced by SNP-4857.

**New files:**
- `docusaurus/docs/business-app/tickets/_category_.json`
- `docusaurus/docs/business-app/tickets/index.md`

**What's documented:**
- The ticket workspace layout (persistent shell with views sidebar + tab bar)
- Views sidebar: what it is and the four default views (My Tickets, Unassigned, All Open, Escalated)
- Tab bar: how to open a ticket from the list, switch between open tickets, and close tabs
- Tab persistence behavior when navigating between the list and open profiles

---

## New vs. existing docs

**New documentation created.** No existing ticket workspace documentation was found in the repo. The existing `crm/custom-objects.md` covers custom objects generally; the `ai/ai-workforce/custom-ai-employees/ai-support-employee.mdx` covers a chat-based AI support employee — neither covers the ticket management workspace.

---

## Placement reasoning

New top-level section `business-app/tickets/` at sidebar position 8 (after Automations at 7). Tickets are a distinct product module, not a sub-feature of CRM or Conversations.

---

## Acceptance criteria coverage

| AC | Documented |
|----|-----------|
| Shell renders the views sidebar and the open-ticket tab bar | ✅ Intro paragraph + Views sidebar section + Ticket tabs section |
| Opening a ticket from the list adds a tab; clicking an existing tab routes to that ticket's profile; closing a tab removes it | ✅ Ticket tabs section (all three behaviours) |
| Tabs persist when switching between the list and any open profile | ✅ Final paragraph of Ticket tabs section |

---

## Figma / images

No Figma links or images were provided in the JIRA ticket. Images are not included in this PR; a follow-up can add screenshots once the UI is stable.

---

## Skills used

- `pre-push-validation` — validated frontmatter, tags, links, and JSON before committing

---

## Assumptions / limitations

- Default view names (My Tickets, Unassigned, All Open, Escalated) sourced from the referenced Confluence page ([Productizing AI Support Tickets](https://vendasta.jira.com/wiki/spaces/SNAP/pages/4149248026/Productizing+AI+Support+Tickets)). Please verify these match final UI labels.
- No screenshots included pending UI stabilization.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mfe5Z8XNGNsq5ENumNoR95)_