### PR TITLE
Docs: Sales Coach tab available for in-person meeting recordings (CRMAAS-3000)

### DIFF
--- a/docusaurus/docs/business-app/crm/My meetings/meeting-details-page.md
+++ b/docusaurus/docs/business-app/crm/My meetings/meeting-details-page.md
@@ -105,7 +105,7 @@ Use the Summary tab to quickly recall goals and next steps without reviewing the
 
 ## Exploring the Sales Coaching tab
 
-The **Sales Coaching** tab contains detailed analytics generated from the meeting transcript.
+The **Sales Coaching** tab contains detailed analytics generated from the meeting transcript. It is available for both virtual and in-person recorded meetings.
 
 ### Conversation metrics
 


### PR DESCRIPTION
## JIRA

[CRMAAS-3000 — Show the sales coach tab for in-person meeting recordings](https://vendasta.jira.com/browse/CRMAAS-3000)

## Change classification

- **Type:** Feature behavior change — UI/UX
- **Repo:** Business App (end-user-facing documentation)

---

## Summary

Updated the **Meeting Details page** article to clarify that the Sales Coaching tab is available for both virtual and in-person recorded meetings.

Previously the documentation described the Sales Coaching tab for "recorded meetings" without specifying meeting type. Users coming from an in-person meeting context might have been unsure whether Sales Coach analysis applied to them. One sentence was added to make this explicit.

---

## What changed

**File:** `docusaurus/docs/business-app/crm/My meetings/meeting-details-page.md`

Added to the opening line of the **Exploring the Sales Coaching tab** section:

> "It is available for both virtual and in-person recorded meetings."

---

## Existing docs updated or new docs created?

Existing doc updated. No new pages created.

---

## Placement reasoning

The Sales Coaching tab section of the Meeting Details page is the natural location for this clarification — it is where users learn what the tab does and will look if they wonder whether it applies to their meeting type.

---

## Acceptance criteria coverage

| AC | Covered? |
|----|----------|
| Show the sales coach tab for in-person meeting | ✅ Documented |

---

## Figma / visuals used

No Figma links or images were provided with this ticket.

---

## Skills used

- `pre-push-validation` — verified frontmatter, tags, links, and structure

---

## Assumptions / limitations

None. The implementation (vendasta/galaxy PR #33065 by @MustakimBillah) confirms the tab is shown identically for in-person meetings as for virtual meetings.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eaj4jb7mKFr3NTMfNrpgeT)_