### PR TITLE
Docs: Add AEO Audit documentation (LIS-2643)

### DIFF
--- a/docusaurus/docs/local-seo/aeo-audit/_category_.json
+++ b/docusaurus/docs/local-seo/aeo-audit/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "AEO Audit",
+  "position": 10,
+  "collapsible": true,
+  "collapsed": true,
+  "link": {
+    "type": "doc",
+    "id": "local-seo/aeo-audit/index"
+  }
+}

--- a/docusaurus/docs/local-seo/aeo-audit/index.md
+++ b/docusaurus/docs/local-seo/aeo-audit/index.md
@@ -1,0 +1,40 @@
+---
+title: AEO Audit
+description: Learn how the AEO Audit automatically evaluates your website's readiness for AI-powered search and tracks your progress over time.
+keywords: [AEO audit, AI search readiness, readiness score, local seo premium, AI search]
+sidebar_position: 1
+---
+
+# AEO Audit
+
+The AEO Audit evaluates your website's readiness for AI-powered search. It crawls your site, runs an AI analysis, and produces a Readiness Score with a prioritized list of improvements.
+
+## How the AEO Audit works
+
+When you activate Local SEO Premium, the system automatically starts your first audit. It crawls up to 50 pages of your website and produces:
+
+- **Readiness Score** — an overall score reflecting how prepared your site is for AI search
+- **Top 5 Fixes** — a prioritized list of improvements across Schema, Robots.txt, JSON-LD, Metadata, Content, and Speed
+
+The first time you open the AEO Dashboard, your completed results are ready to view.
+
+## Automatic monthly audits
+
+After the initial audit, your site is re-audited automatically each month. This keeps your Readiness Score current and lets you track improvement over time.
+
+If you activate Local SEO Premium mid-month, your first audit runs on the day of activation. The next audit runs on the next scheduled monthly date.
+
+:::info
+If you update your website after an audit has already started, the changes are reflected in the next scheduled audit, not the current one.
+:::
+
+## Run an audit manually
+
+You can trigger an audit outside of the monthly schedule. Manual audits use credits from your account.
+
+- If you have enough credits, the audit starts immediately.
+- If you do not have enough credits, you will be prompted to purchase more.
+
+## View your audit history
+
+Each completed audit is saved. From the AEO Dashboard, you can view past Readiness Scores and compare results over time to measure your progress.


### PR DESCRIPTION
## JIRA

[LIS-2643 — Run AEO audit report once a month](https://vendasta.jira.com/browse/LIS-2643)

---

## Change Classification

**Feature behavior change** — New automated AEO Audit scheduling for Local SEO Premium users (SMB-facing)

**Repo:** Business App (end-user documentation)

---

## Summary

Added a new **AEO Audit** section under Local SEO (`docusaurus/docs/local-seo/aeo-audit/`) documenting:

- How the initial audit triggers automatically upon activating Local SEO Premium (deep-crawl up to 50 pages, AI analysis)
- What the AEO Dashboard shows on first visit: Readiness Score + Top 5 Fixes (Schema, Robots.txt, JSON-LD, Metadata, Content, Speed)
- Automatic monthly re-audit cadence and mid-month activation behavior
- Credit-based manual re-runs with purchase prompt when credits are insufficient
- Historical audit result storage for trend tracking

---

## New vs. Updated Documentation

**New documentation created.** No existing AEO or AI search readiness content was found in this repository. A new section was required.

**Placement:** `docusaurus/docs/local-seo/aeo-audit/` at sidebar position 10 (after Analytics at position 9), as this is a Local SEO Premium feature.

---

## Acceptance Criteria Coverage

| AC | Documented |
|----|------------|
| AC1: Initial audit triggers automatically on Premium activation (deep-crawl up to 50 pages) | ✅ |
| AC2: AEO Dashboard shows completed Readiness Score + Top 5 Fixes on first visit | ✅ |
| AC3: Monthly automatic re-audit cadence | ✅ |
| AC4: Manual re-runs require credits; prompt to purchase if insufficient | ✅ |
| AC5: Historical results stored for comparisons over time | ✅ |
| AC6: Mid-month activation — audit runs on activation day, then next on scheduled date | ✅ |
| AC7: Website changes after audit starts → reflected in next scheduled run only | ✅ |

---

## Figma / Images

No Figma links or screenshots were provided in the JIRA ticket. No images included.

---

## Partner Center

No Partner Center update required. This feature is entirely SMB-facing (Business App). The Partner Center has no existing Local SEO product documentation home for this type of content.

---

## Skills Used

- `pre-push-validation` — validated frontmatter, tags, links, and `_category_.json` before push

---

## Assumptions & Limitations

- The exact monthly schedule date (1st of month per implementation; last Wednesday per PM comment) was intentionally described as "monthly" in user-facing docs to avoid documenting an implementation detail that may change.
- No screenshots available; article is text-only.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01YK1C2MeZPMW3vRrCpvUJBg)_