### PR TITLE
Docs: AI draft review response email notification (REP-2680)

### DIFF
--- a/docusaurus/docs/business-app/administration/notification_settings.mdx
+++ b/docusaurus/docs/business-app/administration/notification_settings.mdx
@@ -75,6 +75,7 @@ _All default: Enabled_
 <TabItem value="review-management" label="Review Management">
 
 ### Instant email notifications
+- AI Review Response Draft Ready
 - Edited Review
 - Google Answer / Question
 - Removed Review

--- a/docusaurus/docs/business-app/ai/ai-workforce/ai-reputation-specialist.md
+++ b/docusaurus/docs/business-app/ai/ai-workforce/ai-reputation-specialist.md
@@ -163,6 +163,29 @@ Use the conversational interface to:
 
 ![Configure AI Reputation Specialist](../img/AI-Rep-Spec-16.png)
 
+## Email and in-app notifications for AI draft responses
+
+When the AI Reputation Specialist generates a draft review response, you receive a notification by email and in the app. The notification lets you act on the draft without opening the app first.
+
+The action buttons in the notification email vary by review source:
+
+| Review source | Available buttons |
+|---|---|
+| Connected Google or Facebook account | **Edit**, **Approve & Post** |
+| All other sources (Yelp, TripAdvisor, etc.) | **Edit**, **Respond on source** |
+
+- **Edit** — Opens the draft editor in the Reviews page so you can refine the response before posting.
+- **Approve & Post** — Takes you to the Reviews page and shows a confirmation prompt. The response is not posted automatically — you must click the confirm button on the page to publish it.
+- **Respond on source** — Opens the draft editor and directs you to respond manually on the review platform.
+
+If you click a link while not logged in, you'll sign in first and then land on the review.
+
+If the draft has already been posted when you click a link, you'll see the published response — no duplicate post, no error.
+
+Email links expire after 15 days. Clicking an expired link shows a notification in the app.
+
+To manage this notification, go to **Settings → Notification Settings** and look for **AI Review Response Draft Ready** under **Review Management**.
+
 ## Frequently Asked Questions (FAQs)
 
 <details>


### PR DESCRIPTION
## JIRA

[REP-2680 — Email Notification for Drafted review response Edit/Approve](https://vendasta.jira.com/browse/REP-2680)

---

## Change classification

**Feature behavior change** — new email and in-app notification for Business App end users with the AI Reputation Specialist's Draft review response setting enabled.

## Target repo

**Business App** — this notification is delivered to business owners (SMB end users), not partners.

---

## Summary of changes

### Updated: `docusaurus/docs/business-app/ai/ai-workforce/ai-reputation-specialist.md`

Added a new section **"Email and in-app notifications for AI draft responses"** covering:
- When the notification is sent (on each new AI-generated draft)
- Which action buttons appear, by review source type:
  - Connected Google/Facebook → **Edit** + **Approve & Post**
  - All other sources (Yelp, TripAdvisor, etc.) → **Edit** + **Respond on source**
- What each button does, including the safety note that Approve & Post requires an in-page confirm click (never auto-posts)
- Behavior for unauthenticated link clicks (SSO first, then lands on review)
- Behavior when draft is already posted (shows published response, no error)
- Link expiry (15 days)
- How to manage the notification setting (**Settings → Notification Settings → AI Review Response Draft Ready**)

### Updated: `docusaurus/docs/business-app/administration/notification_settings.mdx`

Added **"AI Review Response Draft Ready"** to the Review Management instant email notifications list.

---

## Existing docs updated or new docs created?

Existing docs updated — content added to the most relevant existing article (AI Reputation Specialist) and the notification reference page. No new pages created.

## Placement reasoning

The AI Reputation Specialist article is the canonical home for how that feature works, including its draft response behavior. A new standalone article would be disconnected and harder to discover.

The notification settings article lists every notification type by product — adding the new type there keeps the reference complete.

---

## Acceptance criteria coverage

| Criterion | Documented |
|---|---|
| Draft notification email sent when toggle is on | ✅ (section intro) |
| Approve & Post and Edit CTAs in email | ✅ (table + button descriptions) |
| CTA gating by source (Google/FB vs redirect-only) | ✅ (table by source type) |
| Approve never auto-posts from email link | ✅ (explicit note) |
| Unauthenticated click → SSO → reviews page | ✅ |
| Already-posted draft → shows posted response | ✅ |
| Link TTL 15 days | ✅ |
| Notification manageable in settings | ✅ (with exact UI label) |

---

## Figma / images used

No Figma links were available. Content is based entirely on the JIRA story and linked GitHub PRs.

---

## Skills used

- `pre-push-validation` — ran before commit; all checks passed

---

## Assumptions / limitations

- The standard "new review received" email continues to be sent in addition to the draft notification when the toggle is on. This dual-email behavior is an accepted limitation noted in the JIRA ticket and is not documented here to avoid confusion for end users.
- The feature is behind a feature flag; documentation reflects the intended shipped behavior.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cz22U12g2rgvvnTApLQnwv)_