### PR TITLE
Docs: Restrict Customize Options for standard CRM fields (CRMAAS-2694)

### DIFF
--- a/docusaurus/docs/business-app/administration/crm-objects/app_settings_crm_fields.md
+++ b/docusaurus/docs/business-app/administration/crm-objects/app_settings_crm_fields.md
@@ -25,7 +25,7 @@ Custom fields let you tailor your system so it works for **your business**, keep
 - Full visibility and editing from the custom field manager
 
 :::info
-System fields (like company name or phone number) cannot be edited or deleted. Custom fields are fully configurable.
+System fields cannot be edited or deleted. For certain standard fields—including **Email**, **Phone number**, **First name**, and **Last name** (Contacts only), as well as **Record source**, **Record source drill down 1**, and **Record source drill down 2**—the **Customize Options** control is disabled. These fields use values required by system features or integrations.
 :::
 
 ## How to Create a CRM Field
@@ -64,7 +64,12 @@ Use `String List` when you want to associate multiple values with a single field
 - You can update the description or field type, but object and identifier may be locked after creation.
 - Fields that were added manually can be deleted when no longer needed.
 
-NOTE: System fields (created by default) cannot be modified or deleted. Only custom fields allow full control.
+System fields cannot be modified or deleted. For the following standard fields, the **Customize Options** control is disabled because their values are required by system features or integrations:
+
+- **Email**, **Phone number**, **First name**, **Last name** (Contact records only)
+- **Record source**, **Record source drill down 1**, **Record source drill down 2**
+
+Only custom fields allow full editing control.
 
 ![CRM Fields inside Administration](../img/administration_custom_fields.png)
 
@@ -131,7 +136,9 @@ Not all views support filtering by custom fields. Check your record view or expo
 <details>
 <summary>Can I edit system fields?</summary>
 
-No. System fields like `Company name` are locked and cannot be edited or removed.
+No. System fields are locked and cannot be edited or removed.
+
+For certain standard fields—**Email**, **Phone number**, **First name**, **Last name** (Contacts only), **Record source**, **Record source drill down 1**, and **Record source drill down 2**—the **Customize Options** control is also disabled. When you open one of these fields, a message explains that its values are required by system features or integrations and cannot be changed.
 
 </details>
 


### PR DESCRIPTION
## JIRA

[CRMAAS-2694 — Restrict user from customizing the field option for standard fields](https://vendasta.jira.com/browse/CRMAAS-2694)

---

## Change classification

**UI/UX change + Feature behavior change** — CRM admin field settings UI now disables the **Customize Options** control for specific standard and system fields.

---

## Repo

**Business App** — This change affects the CRM admin experience within Business App. Partner Center docs were reviewed and do not require updates (the Partner Center CRM Objects docs cover partner-level account/user/product fields, not Business App contact/company field option customization).

---

## Summary of documentation updates

Updated **`docusaurus/docs/business-app/administration/crm-objects/app_settings_crm_fields.md`** — the primary CRM Fields article for Business App admins.

### What changed

| Location | Update |
|---|---|
| `:::info` callout (What's Included section) | Expanded to name the specific standard fields that have **Customize Options** disabled and explain why |
| Managing and Editing section (`NOTE:`) | Replaced the vague "system fields cannot be modified" note with a clear list of the restricted fields and the reason (values required by system features or integrations) |
| FAQ — "Can I edit system fields?" | Updated to explain the **Customize Options** restriction for the named fields, including the in-app message behavior |

### Existing documentation updated (no new page created)

The existing CRM Fields article already documented that system fields are locked. This update extends that content to specifically address the **Customize Options** control and the named standard fields — a natural fit within the existing article structure.

---

## Acceptance criteria coverage

| AC | Documented |
|---|---|
| System fields have Customize Options disabled | ✅ Mentioned in info callout and Managing section |
| Email, phone number, first name, last name (Contact only) have Customize Options disabled | ✅ Explicitly listed |
| Record source, Record source drill down 1, Record source drill down 2 have Customize Options disabled | ✅ Explicitly listed |
| Message explains fields cannot be modified because values are required by system features or integrations | ✅ Reflected in FAQ answer |

---

## Placement reasoning

Updated the existing CRM Fields article (`app_settings_crm_fields.md`) — no new page needed. The article already covers field management and system field restrictions; this change fits directly within that context.

---

## Figma / images

None provided or referenced in the JIRA ticket. The code PR included a screen recording confirming the UI behavior, which was used to validate the documented behavior.

---

## Skills used

- `pre-push-validation` — passed with no errors

---

## Assumptions / limitations

- No Figma link was available; behavior documented from JIRA acceptance criteria and merged code PR description.
- Email field is noted as a Contact-only restriction for first name / last name per the AC; record source fields apply across object types but are listed without object-type qualification per the AC wording.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_011kaCkWXsdaeG6DVZWLffcE)_