### PR TITLE
docs: update Advertising Intelligence settings articles from Guru cleanup

### DIFF
--- a/docusaurus/docs/ad-intel/settings/callrail.mdx
+++ b/docusaurus/docs/ad-intel/settings/callrail.mdx
@@ -10,50 +10,48 @@ description: Learn how to connect CallRail to Advertising Intelligence
 
 Connect CallRail to Advertising Intelligence to view call tracking data.
 
-## Prerequisites
+## Requirements
 
-Before connecting CallRail, ensure you have:
+CallRail connection requires Advertising Intelligence Pro. You also need:
 
-- An active Advertising Intelligence account
 - A CallRail account with access to your API key
+
+## How to connect CallRail
 
 ![Settings Connections page](img/settings-connections.jpg)
 
-1. In Advertising Intelligence, go to **Settings** > **Connections**.
+1. In Advertising Intelligence, go to `Settings` > `Connections`.
 
 ![CallRail connection option](img/callrail-connection.jpg)
 
-2. Select **CallRail** from the connection options.
+2. Select `CallRail` from the connection options.
 
 ![API Key entry field](img/api-key-entry.jpg)
 
-3. Enter your CallRail API key in the field provided and select **Save** or the equivalent button to continue.
+3. Enter your CallRail API key in the field provided.
 
 ![Account and tracking number selection](img/account-selection.jpg)
 
-![API key entry field for CallRail](./img/api-key-entry.jpg)
+4. Select a campaign from the list that appears. Selecting a campaign is required to complete the connection.
+
+5. Select `Connect Account`.
 
 ![Successful connection confirmation](img/connection-success.jpg)
 
-![Account and tracking number selection for CallRail](./img/account-selection.jpg)
-
-5. After the connection succeeds, Advertising Intelligence confirms that CallRail is connected.
-
-![Successful CallRail connection confirmation](./img/connection-success.jpg)
+6. Advertising Intelligence confirms that CallRail is connected.
 
 ## Viewing CallRail data
 
-After connecting CallRail, view your call data in the **Phone Calls** page of Advertising Intelligence. This data includes calls tracked by CallRail for the accounts and tracking numbers you selected during setup.
+After connecting CallRail, view your call data in the `Phone Calls` page of Advertising Intelligence.
 
 ![Phone Calls reporting page](img/phone-calls-view.jpg)
 
 ## Troubleshooting
 
-:::tip Connection issues
-If you encounter issues connecting CallRail:
+:::tip Connection stuck loading
+If the connection is stuck loading after you enter your API key:
 
-1. Verify your API key is correct and has not been regenerated in CallRail.
-2. Check that your CallRail account is active.
-3. Ensure you have permissions to access the CallRail data.
-4. If problems persist, contact your support team.
+1. Confirm your account is on Advertising Intelligence Pro. The campaign selection step requires this plan.
+2. Verify your API key is correct and has not been regenerated in CallRail.
+3. Check that your CallRail account is active and you have the permissions needed to access the data.
 :::

--- a/docusaurus/docs/ad-intel/settings/custom-conversion-selection-for-facebook-ads.mdx
+++ b/docusaurus/docs/ad-intel/settings/custom-conversion-selection-for-facebook-ads.mdx
@@ -4,18 +4,17 @@ sidebar_label: Facebook custom conversions
 description: "Users of Advertising Intelligence that have the Advanced Reporting add-on, can select specific conversion metrics for their Facebook advertising campaigns"
 ---
 
-Users of Advertising Intelligence with the Advanced Reporting add-on can select specific conversion metrics for their Facebook advertising campaigns.
+With the Advanced Reporting add-on, you can select specific conversion metrics for your Facebook advertising campaigns.
 
 ### How does it work?
 
 With the Advanced Reporting add-on activated:
 
-1. Select an **Account** in **Partner Center**
-2. Go to **Advertising Intelligence > Settings.**
-3. Below the connected Facebook Ads account, select **Conversion Metrics**.
-4. In the drop-down menu, select the conversion metrics you want to display for this account. Website Conversions is selected as the default conversion to display.
-5. Select as many conversions as you want to include in the campaign reporting. The selected conversions directly affect the conversion number reported in the product and in the Executive Report.
+1. Go to `Settings` in Advertising Intelligence.
+2. Below the connected Facebook Ads account, select `Conversion Metrics`.
+3. In the drop-down menu, select the conversion metrics you want to display for this account. `Website Conversions` is selected as the default.
+4. Select as many conversions as you want to include in the campaign reporting. The selected conversions directly affect the conversion number reported in the product and in the Executive Report.
 
-   If the account doesn't have Advanced Reporting activated, upgrade by selecting **Purchase Advanced Reporting** from the Overview or Settings page in the product. A Partner can also upgrade this product on behalf of their customer from Partner Center.
+If the account doesn't have Advanced Reporting activated, upgrade by selecting `Purchase Advanced Reporting` from the `Overview` or `Settings` page in Advertising Intelligence.
 
 ![Facebook Ads custom conversion selection](img/custom-conversion-selection.jpg)

--- a/docusaurus/docs/ad-intel/settings/google-ads-conversion-sources-categories.mdx
+++ b/docusaurus/docs/ad-intel/settings/google-ads-conversion-sources-categories.mdx
@@ -6,10 +6,29 @@ description: Learn how to select the metrics you want to track for Google Ads co
 
 # Settings for Google Ads Conversion Sources and Categories
 
-Google Ads conversion has a selector card that lets you select the metrics you want to track for sources and categories.
+Conversion tracking in Advertising Intelligence is not automatic. You need to select which conversion events to track. If conversions are showing as zero, this setup is usually the reason.
 
-Edit these options by opening Advertising Intelligence, then navigate to **Settings > Conversion Metrics** under Google Ads. Select any of the listed metrics to start monitoring.
+## Before you start
+
+Conversion tracking requires the Advanced Reporting add-on. If your account doesn't have it activated, you'll see a prompt to upgrade when you open `Conversion Metrics` in Settings.
+
+## Select your conversion sources and categories
+
+1. In Google Ads, confirm that the conversion events you want to track are defined in your account.
+2. Open Advertising Intelligence and go to `Settings`.
+3. Under your connected Google Ads account, select `Conversion Metrics`.
+4. Choose a `Conversion Source` and `Conversion Category` to start tracking.
 
 ![Google Ads conversion metrics selector](img/conversion-metrics-selector.jpg)
 
 ![Google Ads conversion metrics options](img/conversion-metrics-options.jpg)
+
+## Why Advertising Intelligence may show fewer conversions than Google Ads
+
+Google Ads reports two conversion totals: `Conversions` and `All Conversions`. Advertising Intelligence uses the `Conversions` value only. If you see a higher number in Google Ads, you're likely comparing it against `All Conversions`, which includes additional tracked actions that Google Ads counts separately.
+
+## Troubleshooting: Conversions still showing zero
+
+1. Confirm the Advanced Reporting add-on is active for this account.
+2. Verify that a `Conversion Source` and `Conversion Category` are selected under `Settings` > `Conversion Metrics`.
+3. Clear your browser cache and reload the page.

--- a/docusaurus/docs/ad-intel/settings/index.mdx
+++ b/docusaurus/docs/ad-intel/settings/index.mdx
@@ -155,3 +155,13 @@ Yes. Connect Google Analytics to pull conversion data into Advertising Intellige
 
 The dashboard displays data in the currency configured for your connected advertising account. The currency matches your Facebook or Google Ads account settings. See the [Currency display](#currency-display) section above for details.
 </details>
+
+<details>
+<summary>Can I download ad spend receipts from Advertising Intelligence?</summary>
+
+Advertising Intelligence displays ad spend data pulled from your connected platforms but does not store or generate billing receipts.
+
+**To adjust how spend is displayed:** Go to `Settings` > `Connections`, click the three-dot menu next to your connection, and select `Edit Management Fee`. This adds a percentage on top of the base spend figure shown in the dashboard.
+
+**To get billing receipts:** Log in to the ad platform directly, for example the Google Ads or Facebook Ads billing section, and download receipts from there.
+</details>

--- a/docusaurus/docs/ad-intel/settings/track-conversions-with-google-analytics.mdx
+++ b/docusaurus/docs/ad-intel/settings/track-conversions-with-google-analytics.mdx
@@ -8,16 +8,18 @@ Select Google Analytics as the source for your Conversion metrics in Advertising
 
 ![Google Analytics conversion tracking](img/ga-conversion-1.jpg)
 
-### Why is Google Analytics conversion tracking important?
+## Supported Google Analytics account types
 
-Previously, Conversion metrics could only be tracked from objectives set on Google Ads or Facebook Ads. However, it's common for Partners to set objectives in Google Analytics since it has broader access to the sales funnel and can track ads campaign performance in more detail. When objectives were set in Google Analytics, the Conversions metric showed as 0 since Advertising Intelligence wasn't tracking Google Analytics.
+Standard GA4 properties are supported. Google Analytics 360 sub-properties are not supported. If you attempt to connect a GA 360 sub-property, the connection will not work.
 
-Select the platform you're using to set objectives, giving you complete transparency into the data as well as flexibility in selecting and analyzing the conversions.
+## How to set up Google Analytics conversion tracking
 
-### How does tracking conversions with Google Analytics work?
-
-To configure your Conversion metric settings, open **Advertising Intelligence** and navigate to the **Settings** page. Then, click the **Conversion Metrics** section under Google AdWords or Facebook Ads to configure the settings for that platform. The option you select supplies the data for the Conversions metric in Advertising Intelligence.
-
-Advertising Intelligence pulls in and stores this data once per day. The data comes from the **"sessions" column** (not users) in the Google Analytics dashboard. If there are small differences in the data (between GA dashboard and Advertising Intelligence), it's caused by how frequently we fetch Google Analytics data. New session data may get pulled into Google Analytics before we pull it and store it.
+1. Open Advertising Intelligence and go to `Settings`.
+2. Click the `Conversion Metrics` section under Google Ads or Facebook Ads.
+3. Select `Google Analytics` as the source. The option you select supplies the data for the Conversions metric in Advertising Intelligence.
 
 ![Google Analytics conversion metrics settings](img/ga-conversion-2.jpg)
+
+## Why is there a data difference between Google Analytics and Advertising Intelligence?
+
+Advertising Intelligence pulls and stores Google Analytics data once per day. The data comes from the `Sessions` column (not Users) in the Google Analytics dashboard. Small differences between the GA dashboard and Advertising Intelligence are normal. New session data may be added to Google Analytics between pulls, so Advertising Intelligence may lag the live GA dashboard by up to 24 hours.


### PR DESCRIPTION
## Summary

- **`google-ads-conversion-sources-categories`**: Expanded from a 2-sentence stub into a full article — added Advanced Reporting requirement, 4-step setup process, Conversions vs. All Conversions explanation, and zero-conversions troubleshooting
- **`track-conversions-with-google-analytics`**: Added GA 360 sub-property not-supported callout, fixed evergreen language violation ("Previously…"), removed "Partners" language
- **`callrail`**: Added Advertising Intelligence Pro requirement, inserted missing campaign-selection step, removed duplicate image references, improved troubleshooting tip for stuck-loading issue
- **`settings/index`**: Added FAQ for ad spend receipts, including management fee display adjustment and where to get billing receipts
- **`custom-conversion-selection-for-facebook-ads`**: Removed two Partner Center references (gray-label violation), renumbered steps

All five articles updated to use backtick formatting for UI elements and navigation paths per style guide. Em dashes replaced throughout.

Source: June 2026 Guru card audit (15 cards consolidated to 10, 4 recommendations applicable to existing articles).

## Test plan

- [ ] Confirm no build errors (frontmatter, links, tags)
- [ ] Verify UI label formatting (backticks) matches style guide
- [ ] Check that no Vendasta/Partner Center references remain
- [ ] Confirm evergreen language throughout (no "previously", "formerly", etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)